### PR TITLE
Make compatible with new tf_mem version that uses array for nentries …

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1,16 +1,17 @@
-########################################
+"""
 # Utilities for writing Verilog code from Vivado HLS blocks
-########################################
+"""
+
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule
 from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination
 import re
 
-########################################
-# Memory objects
-########################################
 def getMemoryClassName_InputStub(instance_name):
+    """
+    # Memory objects
     # Two examples of instance name: IL_L1PHIB_neg_PS10G_1_A, IL_L1PHIH_PS10G_2_B
+    """
     position = instance_name.split('_')[1][:2] # layer/disk
     ptmodule = instance_name.replace('_neg','').split('_')[2][:2] # PS or 2S
 
@@ -27,7 +28,9 @@ def getMemoryClassName_InputStub(instance_name):
     return 'InputStubMemory<'+bitformat+'>'
 
 def getMemoryClassName_VMStubsTE(instance_name):
+    """
     # An example of instance name: VMSTE_L6PHIB15n3
+    """
     position = instance_name.split('_')[1][:2] # layer/disk
     philabel = instance_name.split('_')[1][5] # PHI
 
@@ -97,7 +100,9 @@ def getMemoryClassName_VMStubsTE(instance_name):
     return memoryclass+'<'+bitformat+'>'
 
 def getMemoryClassName_VMStubsME(instance_name):
+    """
     # An example of instance name: VMSME_D3PHIB8n1
+    """
     position = instance_name.split('_')[1][:2] # layer/disk
     bitformat = ''
     
@@ -112,10 +117,10 @@ def getMemoryClassName_VMStubsME(instance_name):
     return 'VMStubMEMemory<'+bitformat+'>'
 
 def getMemoryClassName_AllStubs(instance_name):
-    ######################
+    """
     # FIXME: separate Disk PS and 2S AllStub memories for MatchCalculator
     # when config files are updated
-    ######################
+    """
     
     # An example of instance name: AS_D1PHIAn5
     position = instance_name.split('_')[1][:2]
@@ -129,17 +134,23 @@ def getMemoryClassName_AllStubs(instance_name):
         raise ValueError("Unknown Layer/Disk "+position)
     
 def getMemoryClassName_StubPairs(instance_name):
+    """
     # e.g. SP_L1PHIA2_L2PHIA3
+    """
     assert('SP_' in instance_name)
     return 'StubPairMemory'
 
 def getMemoryClassName_TrackletParameters(instance_name):
+    """
     # e.g. TPAR_L1L2L
+    """
     assert('TPAR_' in instance_name)
     return 'TrackletParameterMemory'
 
 def getMemoryClassName_TrackletProjections(instance_name):
+    """
     # e.g. TPROJ_L5L6A_L1PHIB
+    """
     position = instance_name.split('_')[2][:2] # layer/disk
     bitformat = ''
 
@@ -154,7 +165,9 @@ def getMemoryClassName_TrackletProjections(instance_name):
     return 'TrackletProjectionMemory<'+bitformat+'>'
 
 def getMemoryClassName_AllProj(instance_name):
+    """
     # e.g. AP_L4PHIB
+    """
     position = instance_name.split('_')[1][:2] # layer/disk
     bitformat = ''
 
@@ -169,7 +182,9 @@ def getMemoryClassName_AllProj(instance_name):
     return 'AllProjectionMemory<'+bitformat+'>'
 
 def getMemoryClassName_VMProjections(instance_name):
+    """
     # e.g. VMPROJ_D3PHIA2
+    """
     position = instance_name.split('_')[1][:2] # layer/disk
     if position in ['L1','L2','L3','L4','L5','L6']:
         return 'VMProjectionMemory<BARREL>'
@@ -178,12 +193,16 @@ def getMemoryClassName_VMProjections(instance_name):
         return 'VMProjectionMemory<DISK>'
 
 def getMemoryClassName_CandidateMatch(instance_name):
+    """
     # e.g. CM_L2PHIA8
+    """
     assert('CM_' in instance_name)
     return 'CandidateMatchMemory'
 
 def getMemoryClassName_FullMatch(instance_name):
+    """
     # e.g. FM_L5L6_L3PHIB
+    """
     position = instance_name.split('_')[2][:2]
     if position in ['L1','L2','L3','L4','L5','L6']:
         return 'FullMatchMemory<BARREL>'
@@ -192,12 +211,16 @@ def getMemoryClassName_FullMatch(instance_name):
         return 'FullMatchMemory<DISK>'
 
 def getMemoryClassName_TrackFit(instance_name):
+    """
     # e.g. TF_L3L4
+    """
     assert('TF_' in instance_name)
     return 'TrackFitMemory'
 
 def getMemoryClassName_CleanTrack(instance_name):
+    """
     # e.g. CT_L5L6
+    """
     assert('CT_' in instance_name)
     return 'CleanTrackMemory'
 
@@ -233,11 +256,13 @@ def getHLSMemoryClassName(module):
         raise ValueError(module.mtype + " is unknown.")
 
 def labelConnectedMemoryArrays(proc_list):
+    """
     # label those memories that will be constructed in an array
     # (if these scripts end up generating the HLS top levels, will this function
     # be needed? That is, even if the templated HLS function has arrays on the
     # interface, the top-level could still be individual memories, although you'd
     # still have to pass those individual memories to the templated block as an array
+    """
     for aProcModule in proc_list:
 
         if aProcModule.mtype == 'TrackletCalculator':
@@ -255,11 +280,13 @@ def labelConnectedMemoryArrays(proc_list):
         #elif aProcModule.mtype == '':
 
 def getListsOfGroupedMemories(aProcModule):
+    """
     # Get a list of memories and a list of ports for a given processing module
     # The memories are further grouped in a list if they are expected to be
     # constructed and passed to the processing function as an array
 
     # add array name to 'userlabel' of the connected memory module
+    """
     labelConnectedMemoryArrays([aProcModule])
 
     memList = list(aProcModule.upstreams + aProcModule.downstreams)
@@ -288,10 +315,12 @@ def getListsOfGroupedMemories(aProcModule):
     return newmemList, newportList
 
 def groupAllConnectedMemories(proc_list, mem_list):
+    """
     # Regroup memories into the lists called inside, topin, topout
     #   topin:  memories at the top of the fw block, stimulated by test bench
     #   inside: memories internal to the fw block
     #   topout: memories at the bottom of the fw blcok, read by test bench
+    """
 
     memories_topin = []  # input memories at the top function interface
     memories_inside = []  # memories instantiated inside the top function
@@ -336,6 +365,8 @@ def groupAllConnectedMemories(proc_list, mem_list):
 # matchArgPortNames: Match the HLS argument names to the python-generated port names from
 #                    the wires file. Once these scripts also generate the top-level HLS
 #                    blocks, these functions might not be needed
+########################################
+
 ################################
 # VMRouter
 ################################
@@ -470,9 +501,11 @@ def matchArgPortNames_TC(argname, portname):
 ################################
 # ProjectionRouter
 ################################
-####
-# Write ProjectionRouter template parameters
+
 def writeTemplatePars_PR(aPRModule):
+    """
+    # Write ProjectionRouter template parameters
+    """
     instance_name = aPRModule.inst
     # e.g. PR_L3PHIC
     pos = instance_name.split('_')[1][0:2]
@@ -497,10 +530,10 @@ def writeTemplatePars_PR(aPRModule):
     templpars_str = PROJTYPE+','+VMPTYPE+','+str(nInMemory)+','+LAYER+','+DISK
     return templpars_str
 
-####
-# Define rules to match the argument and the port names for ProjectionRouter
 def matchArgPortNames_PR(argname, portname):
-
+    """
+    # Define rules to match the argument and the port names for ProjectionRouter
+    """
     if 'projin' in argname:
         # projXXin for input TrackletProjection memories
         return 'proj' in portname and 'in' in portname
@@ -516,9 +549,11 @@ def matchArgPortNames_PR(argname, portname):
 ################################
 # MatchEngine
 ################################
-####
-# Write MatchEngine template parameters
+
 def writeTemplatePars_ME(aMEModule):
+    """
+    # Write MatchEngine template parameters
+    """
     instance_name = aMEModule.inst
     # e.g. ME_L4PHIC20
     pos = instance_name.split('_')[1][0:2]
@@ -539,10 +574,10 @@ def writeTemplatePars_ME(aMEModule):
     templpars_str = LAYER+','+VMSTYPE
     return templpars_str
 
-####
-# Define rules to match the argument and the port names for MatchEngine
 def matchArgPortNames_ME(argname, portname):
-
+    """
+    # Define rules to match the argument and the port names for MatchEngine
+    """
     if argname == 'inputStubData':
         return portname == 'vmstubin'
     elif argname == 'inputProjectionData':
@@ -556,6 +591,7 @@ def matchArgPortNames_ME(argname, portname):
 ################################
 # MatchCalculator
 ################################
+
 def writeTemplatePars_MC(aMCModule):
     instance_name = aMCModule.inst
     # e.g. MC_L2PHID
@@ -625,6 +661,7 @@ def decodeSeedIndex_MC(memoryname):
 ################################
 # FitTrack
 ################################
+
 def writeTemplatePars_FT(aFTModule):
     raise ValueError("FitTrack is not implemented yet!")
     return ""
@@ -636,6 +673,7 @@ def matchArgPortNames_FT(argname, portname):
 ################################
 # PurgeDuplicate
 ################################
+
 def writeTemplatePars_PD(aPDModule):
     raise ValueError("DuplicateRemoval is not implemented yet!")
     return ""
@@ -644,12 +682,13 @@ def matchArgPortNames_PD(argname, portname):
     raise ValueError("DuplicateRemoval is not implemented yet!")
     return False
 
-################################
 def parseProcFunction(proc_name, fname_def):
+    """
     # Parse the definition of the processing function in the HLS header file
     # Assume all processing functions are templatized
     # Return a list of function argument types, argument names,
     # and template parameters
+    """
     
     # Open the header file
     file_proc_hh = open(fname_def)
@@ -745,7 +784,6 @@ def parseProcFunction(proc_name, fname_def):
 
     return arg_types_list, arg_names_list, templ_pars_list
 
-################################
 def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                               f_matchArgPortNames, first_of_type):
     ####

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -33,10 +33,11 @@ def writeTBModuleCloser(topmodule_name):
     return ""
 
 def writeTBMemoryStimulusInstance(memModule):
+    """
     # Verilog test-bench
     # this will have to change, once Robert has a more sensible method for
     # stimulating the initial memories. But this does work for now
-
+    """
     wirelist = ""
     parameterlist = ""
     portlist = ""
@@ -81,10 +82,11 @@ def writeTBMemoryStimulusInstance(memModule):
     return mem_str
 
 def writeTBMemoryReadInstance(memModule):
+    """
     # Verilog test-bench
     # this will have to change, once Robert has a more sensible method for
     # stimulating the initial memories. But this does work for now
-
+    """
     wirelist = ""
     # Write wires
     wirelist += "wire "+memModule.inst+"_dataarray_data_V_enb;\n"
@@ -97,7 +99,9 @@ def writeTBMemoryReadInstance(memModule):
     return wirelist
 
 def writeTopLevelMemoryInstance(memModule, interface):
+    """
     # Declaration of memories & associated wires
+    """
     wirelist = ""
     parameterlist = ""
     portlist = ""
@@ -171,6 +175,9 @@ def writeTopLevelMemoryInstance(memModule, interface):
     return wirelist,mem_str
 
 def writeControlSignals_interface(initial_proc, final_proc):
+    """
+    # Top-level interface: control signals
+    """
     string_ctrl_signals = ""
     string_ctrl_signals += "    clk        : in std_logic;\n"
     string_ctrl_signals += "    reset      : in std_logic;\n"
@@ -182,7 +189,9 @@ def writeControlSignals_interface(initial_proc, final_proc):
     return string_ctrl_signals
 
 def writeMemoryLHSPorts_interface(memModule):
+    """
     # Top-level interface: input memories' ports.
+    """
     string_input_mems = ""
     string_input_mems += "    "+memModule.inst+"_dataarray_data_V_wea       : in std_logic;\n"
     string_input_mems += "    "+memModule.inst+"_dataarray_data_V_writeaddr : in std_logic_vector("
@@ -192,7 +201,9 @@ def writeMemoryLHSPorts_interface(memModule):
     return string_input_mems
 
 def writeMemoryRHSPorts_interface(memModule):
+    """
     # Top-level interface: output memories' ports.
+    """
     string_output_mems = ""
     string_output_mems += "    "+memModule.inst+"_dataarray_data_V_enb      : in std_logic;\n"
     string_output_mems += "    "+memModule.inst+"_dataarray_data_V_readaddr : in std_logic_vector("
@@ -212,6 +223,9 @@ def writeMemoryRHSPorts_interface(memModule):
     return string_output_mems
 
 def writeTBControlSignals(topfunc, first_proc, last_proc):
+    """
+    # Verilog test bench: control signals
+    """
     string_header = ""
     string_header += "reg clk;\n"
     string_header += "reg reset;\n\n"
@@ -246,6 +260,9 @@ def writeTBControlSignals(topfunc, first_proc, last_proc):
     return string_header
 
 def writeFWBlockControlSignalPorts(first_proc, last_proc):
+    """
+    # Verilog test bench: send control signals to top-level
+    """
     string_fwblock_ctrl = ""
     string_fwblock_ctrl += "  .clk(clk),\n"
     string_fwblock_ctrl += "  .reset(reset),\n"
@@ -258,7 +275,9 @@ def writeFWBlockControlSignalPorts(first_proc, last_proc):
     return string_fwblock_ctrl
 
 def writeFWBlockMemoryLHSPorts(memModule):
-    # Verilog test bench: sent memories to top-level.
+    """
+    # Verilog test bench: send memories to top-level.
+    """
     string_input_mems = ""
     string_input_mems += "  ."+memModule.inst+"_dataarray_data_V_wea(1'b1),\n"
     string_input_mems += "  ."+memModule.inst+"_dataarray_data_V_writeaddr("
@@ -269,7 +288,9 @@ def writeFWBlockMemoryLHSPorts(memModule):
     return string_input_mems
 
 def writeFWBlockMemoryRHSPorts(memModule):
+    """
     # Verilog test bench: returned memories from top-level.
+    """
     string_output_mems = ""
     string_output_mems += "  ."+memModule.inst+"_dataarray_data_V_enb("
     string_output_mems += memModule.inst+"_dataarray_data_V_enb),\n"
@@ -289,7 +310,10 @@ def writeFWBlockMemoryRHSPorts(memModule):
     return string_output_mems
 
 def writeProcCombination(module, str_ctrl_func, special_TC, templpars_str, str_ports):
-# FIXME needs fixing to include template parameters for generic proc module writing
+    """
+    # Instantiation of processing module within top-level.
+    # FIXME needs fixing to include template parameters for generic proc module writing
+    """
     module_str = ""
     module_str += str_ctrl_func
     module_str += special_TC
@@ -299,6 +323,9 @@ def writeProcCombination(module, str_ctrl_func, special_TC, templpars_str, str_p
     return module_str
 
 def writeStartSwitchAndInternalBX(module,mem):
+    """
+    # Top-level: control (start/done) & Bx signals for use by given module
+    """
     int_ctrl_wire = ""
     int_ctrl_wire += "  signal "+module.mtype+"_done : std_logic := '0';\n"
     int_ctrl_wire += "  signal "+mem.downstreams[0].mtype+"_start : std_logic := '0';\n"
@@ -314,6 +341,9 @@ def writeStartSwitchAndInternalBX(module,mem):
     return int_ctrl_wire,int_ctrl_func
 
 def writeProcControlSignalPorts(module,first_of_type):
+    """
+    # Processing module port assignment: control signals
+    """
     string_ctrl_ports = ""
     string_ctrl_ports += "      ap_clk   => clk,\n"
     string_ctrl_ports += "      ap_rst   => reset,\n"
@@ -328,7 +358,9 @@ def writeProcControlSignalPorts(module,first_of_type):
     return string_ctrl_ports
 
 def writeProcBXPort(modName,isInput,isInitial):
-    # BX ports of processing module
+    """
+    # Processing module port assignment: BX ports
+    """
     bx_str = ""
     if isInput and isInitial:
         bx_str += "      bx_V          => bx_in_"+modName+",\n"
@@ -340,7 +372,9 @@ def writeProcBXPort(modName,isInput,isInitial):
     return bx_str
 
 def writeProcMemoryLHSPorts(argname,memory):
-    # Output interface of processing module
+    """
+    # Processing module port assignment: outputs to memories
+    """
     string_mem_ports = ""
     string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => "
@@ -353,7 +387,9 @@ def writeProcMemoryLHSPorts(argname,memory):
     return string_mem_ports
 
 def writeProcMemoryRHSPorts(argname,memory):
-    # Input interface of processing module.
+    """
+    # Processing module port assignment: inputs from memories
+    """
     string_mem_ports = ""
     string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => "
     string_mem_ports += memory.inst+"_dataarray_data_V_enb,\n"

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -24,6 +24,7 @@ import os, subprocess
 ########################################
 
 def writeMemoryModules(mem_list, interface=0):
+    """
     # mem_list: a list memory module(s)
     # inteface: specifies whether mem_list is on the interface of the firmware block
     #           being generated
@@ -32,6 +33,7 @@ def writeMemoryModules(mem_list, interface=0):
     #              1: Final memories, ready by test bench
 
     # the element cound be a list if the memories are grouped in an array
+    """
 
     string_wires = ""
     string_mem = ""
@@ -47,10 +49,12 @@ def writeMemoryModules(mem_list, interface=0):
 # Processing modules
 ########################################
 def writeProcModules(proc_list, hls_src_dir):
+    """
     # proc_list:   a list of processing modules
     # hls_src_dir: string pointing to the HLS directory, used to extract constants
     #              from HLS constants files, and reading/writing bit widths by accessing HLS
     #              <MemoryType>Memory.h files (Not yet implemented)
+    """
 
     string_proc_func = ""
     string_proc_wire = ""
@@ -77,6 +81,7 @@ def writeProcModules(proc_list, hls_src_dir):
 ########################################
 def writeTopModule_interface(topmodule_name, process_list, memories_topin, memories_topout,
                      streamIO=False):
+    """
     # topmodule_name:  name of the top module
     # process_list:    list of all processing functions in the block (in this function, this list is
     #                  only used to get the first and last processes in the block in order to
@@ -87,6 +92,7 @@ def writeTopModule_interface(topmodule_name, process_list, memories_topin, memor
     # streamIO:        controls whether the input to this firmware block is an hls::stream, rather
     #                  than a BRAM interface. This will be needed when the first processing block in the
     #                  chain is input router, and might be needed for the KF. Not yet implemented.
+    """
     
     if streamIO:
         raise ValueError("hls::stream IO is not supported yet.")
@@ -135,9 +141,11 @@ def writeTopModule_interface(topmodule_name, process_list, memories_topin, memor
 ########################################
 def writeTopFile(topfunc, process_list, memList_topin, memList_inside, memlist_topout,
                  hls_dir):
+    """
     # List of (memory module(s), portname)
     # memories inside the top function, input memories at top function interface,
     # output memories at top function interface
+    """
     
     # Write memories
     string_memWires = ""
@@ -182,9 +190,11 @@ def writeTopFile(topfunc, process_list, memList_topin, memList_inside, memlist_t
 # Test bench
 ########################################
 def writeTBMemoryStimuli(memories_list, emData_dir="", sector="04"):
+    """
     # memories_list: list of input memories that the test bench has to initialize
     # emData_dir:    directory where data for input memories is stored
     # sector:        which sector nonant the emData is taken from
+    """
 
     string_mem = ""
     for memModule in memories_list:
@@ -228,10 +238,12 @@ def writeFWBlockInstance(topfunc, memories_in, memories_out, first_proc, last_pr
     return string_fwblock_inst
 
 def writeTestBench(topfunc, memories_in, memories_out, emData_dir, sector="04"):
+    """
     # memories_in:   list of input memories that the test bench has to initialize
     # memories_out:  list of output memories that the test bench will have to read
     # emData_dir:    directory where data for input memories is stored
     # sector:        which sector nonant the emData is taken from
+    """
 
     # Find the first and last processing block in firmware chain
     for memModule in memories_in:
@@ -274,8 +286,10 @@ def writeTcl(projname, topfunc, emData_dir):
     return string_tcl
 
 def getMemPrintDirectory(fname):
+    """
     # return directory name under fpga_emulation_longVM/MemPrints/
     # for a given memory printout file
+    """
     if "InputStubs" in fname:
         return "InputStubs"
     elif "StubPairs" in fname:


### PR DESCRIPTION
This update makes the VHDL written by the scripts compatible with the new tf_mem*.vhd interface created by HLS PR https://github.com/cms-L1TK/firmware-hls/pull/135 (which has now been merged) . It means that the assignment of the "nent_o" port of the memories is now done in a single line of VHDL for each memory. 

To do this, the signals "*nentries*" inside the SectorProcessor.vhd written by the scripts are now arrays, with one element for each page of the memory.
