### PR TITLE
Use arrays & loops to shorten top-level VHDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Basic instructions to run the project generation for the Vivado HLS project with
       		              Choose from A(all), L(barrel), D(disk).
       --uut               Specify a unit under test, e.g. TC_L1L2E
       --mut		  Specify a module under test, e.g PR (Projection Routers)
+      -x                  Give top-level VHDL extra output ports to carry
+      			  debug info to test-bench corresponding to inputs
+			  to all memory modules in chain.
       -u, --nupstream     The number of processing steps to be generated upstream of the UUT or MUT 
       -d, --ndownstream   The number of processing steps to be generated downstream of the UUT or MUT
 

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -45,16 +45,19 @@ ModuleDrawWidth_dict = {'InputLink':3.0,
 # Processing and memory module classes
 class Node(object):
     def __init__(self, module_type, instance_name, i):
-        self.mtype = module_type
+        self.mtype = module_type # Module type (e.g. "TrackletProjections")
         self.inst = instance_name
         self.upstreams = [] # list of pointers to upstream Nodes
         self.downstreams = [] # list of pointers to downstream Nodes
         self.index = i  # instance index from the configuration file
-        self.userlabel = "" # label for customized usage
         # drawing parameters
         self.width = 1.  # Width of the box
         self.xstart = 0  # Starting x coordinate
         self.ycenter = 0  # y coordinate
+    def mtype_short(self):
+        return self.inst.split("_",1)[0] # Short module type (e.g. "TPROJ")
+    def var(self):
+        return self.inst.split("_",1)[-1] # Remainder of instance name
         
 class MemModule(Node):
     def __init__(self, module_type, instance_name, index):
@@ -69,6 +72,8 @@ class MemModule(Node):
         self.bxbitwidth = 0
         self.is_binned = False
         self.has_numEntries_out = True # True if has numEntries out port.
+    def keyName(self): # All mems with same keyName made in same VHDL "generate" loop.
+        return self.mtype_short()+"_"+str(self.bitwidth)
 
 class ProcModule(Node):
     def __init__(self, module_type, instance_name, index):
@@ -80,6 +85,43 @@ class ProcModule(Node):
         self.is_first = False
         self.is_last = False
         self.IPname = instance_name
+
+class MemTypeInfoByKey(object):
+    """
+    # Info common to all memory objects of a given keyName() (e.g. TPROJ_60)
+    """
+    def __init__(self, memList):        
+        # Input: list of all memory objects of a given key type
+        assert(len(memList) > 0)
+        self.mtype_short = memList[0].mtype_short() 
+        self.bitwidth   = memList[0].bitwidth
+        self.bxbitwidth = memList[0].bxbitwidth
+        self.is_binned  = memList[0].is_binned
+        self.has_numEntries_out = memList[0].has_numEntries_out
+        # At least one memory of this type is initial or final.
+        self.is_initial = any(m.is_initial for m in memList)
+        self.is_final   = any(m.is_final for m in memList)
+        assert(not (self.is_initial and self.is_final))
+        # Short type name of any upstream/downstream processing module.
+        self.upstream_mtype_short   = ""
+        self.downstream_mtype_short = ""
+        # Indicates if some modules of this type take have upstream/downstream
+        # connections and others do not.
+        self.mixedIO = False; 
+        keySet = set()
+        for m in memList:
+            keySet.add(m.keyName())
+            if len(m.upstreams) > 0:
+                self.upstream_mtype_short = m.upstreams[0].mtype_short()
+            if len(m.downstreams) > 0:
+                self.downstream_mtype_short = m.downstreams[0].mtype_short()
+            if (self.is_initial and not m.is_initial) or (self.is_final and not m.is_final):
+                self.mixedIO = True
+        assert(len(keySet) == 1) # Ensure only one key name is input memory list.
+        if self.mixedIO:
+            print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
+            exit(1)
+
 
 #######################################
 # Tracklet Graph

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -261,21 +261,11 @@ def getHLSMemoryClassName(module):
 def getListsOfGroupedMemories(aProcModule):
     """
     # Get a list of memories and a list of ports for a given processing module
-    # The memories are further grouped in a list if they are expected to be
-    # constructed and passed to the processing function as an array
     """
     memList = list(aProcModule.upstreams + aProcModule.downstreams)
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
-    # sort?
 
-    newmemList = []
-    newportList = []
-
-    for memory, portname in zip(memList, portList):
-        newmemList.append(memory)
-        newportList.append(portname)
-
-    return newmemList, newportList
+    return memList, portList
 
 def arrangeMemoriesByKey(memory_list):
     """

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -309,12 +309,11 @@ def writeMemoryLHSPorts_interface(mtypeB, extraports=False):
 
     return string_input_mems
 
-def writeMemoryRHSPorts_interface(mtypeB, memList, memInfo):
+def writeMemoryRHSPorts_interface(mtypeB, memInfo):
     """
     # Top-level interface: output memories' ports.
     # Inputs:
     #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
-    #   memList = list of memories of given type & bit width
     #   memInfo = Info about each memory type (in MemTypeInfoByKey class)
     """
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,12 +1,18 @@
-def writeTopPreamble():
+from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
+
+def writeTopPreamble(all=True):
     string_preamble = "--! Standard libraries\n"
     string_preamble += "library IEEE;\n"+"use IEEE.STD_LOGIC_1164.ALL;\n"
     string_preamble += "--! User packages\n"
-    string_preamble += "use work.tf_pkg.all;\n\n"
+    string_preamble += "use work.tf_pkg.all;\n"
+    if all:
+        string_preamble += "use work.memUtil_pkg.all;\n"
+    string_preamble += "\n"
     return string_preamble
 
 def writeModulesPreamble():
-    string_preamble = "\n begin \n"
+    string_preamble = "\n"
+    string_preamble = "begin\n\n"
     return string_preamble
 
 def writeTBPreamble():
@@ -21,7 +27,7 @@ def writeTBOpener(topfunc):
     return string_tb_opener
 
 def writeTopModuleEntityCloser(topmodule_name):
-    string_closer = "\n\nend "+topmodule_name+";\n\n"
+    string_closer = "end "+topmodule_name+";\n\n"
     string_closer += "architecture rtl of "+topmodule_name+" is\n\n"
     return string_closer
 
@@ -44,20 +50,20 @@ def writeTBMemoryStimulusInstance(memModule):
     mem_str = ""
     # Write wires
     wirelist += "reg["+str(6+memModule.bxbitwidth)+":0] "
-    wirelist += memModule.inst+"_dataarray_data_V_readaddr = 8'b00000000;\n"
+    wirelist += memModule.inst+"_mem_V_readaddr = 8'b00000000;\n"
     wirelist += "reg["+str(6+memModule.bxbitwidth)+":0] "
-    wirelist += memModule.inst+"_dataarray_data_V_writeaddr = "
-    wirelist += memModule.inst+"_dataarray_data_V_readaddr - 2;\n"
+    wirelist += memModule.inst+"_mem_V_writeaddr = "
+    wirelist += memModule.inst+"_mem_V_readaddr - 2;\n"
     wirelist += "wire["+str(memModule.bitwidth-1)+":0] "
-    wirelist += memModule.inst+"_dataarray_data_V_dout;\n"
+    wirelist += memModule.inst+"_mem_V_dout;\n"
     for i in range(0,2**memModule.bxbitwidth):
         wirelist += "reg[6:0] "+memModule.inst+"_nentries_"
         wirelist += str(i)+"_V_dout = 7'b1101100;\n"
     wirelist += "always @(posedge clk) begin\n  "
-    wirelist += memModule.inst+"_dataarray_data_V_readaddr <= "
-    wirelist += memModule.inst+"_dataarray_data_V_readaddr + 1;\n"
-    wirelist += memModule.inst+"_dataarray_data_V_writeaddr <= "
-    wirelist += memModule.inst+"_dataarray_data_V_writeaddr + 1;\n"
+    wirelist += memModule.inst+"_mem_V_readaddr <= "
+    wirelist += memModule.inst+"_mem_V_readaddr + 1;\n"
+    wirelist += memModule.inst+"_mem_V_writeaddr <= "
+    wirelist += memModule.inst+"_mem_V_writeaddr + 1;\n"
     wirelist += "end\n\n"
 
     # Write parameters
@@ -72,11 +78,11 @@ def writeTBMemoryStimulusInstance(memModule):
     portlist += "  .clkb(clk),\n"
     portlist += "  .enb(1'b1),\n"
     portlist += "  .regceb(1'b1),\n"  
-    portlist += "  .addrb("+memModule.inst+"_dataarray_data_V_readaddr),\n"
-    portlist += "  .doutb("+memModule.inst+"_dataarray_data_V_dout),\n"
+    portlist += "  .addrb("+memModule.inst+"_mem_V_readaddr),\n"
+    portlist += "  .doutb("+memModule.inst+"_mem_V_dout),\n"
     portlist += "  .sync_nent(1'b0),\n"
   
-    mem_str += wirelist + "\n"+"tf_mem #(\n"+parameterlist.rstrip("\n,")+"\n) "
+    mem_str += wirelist + "\n"+"tf_mem (\n"+parameterlist.rstrip(",\n")+"\n) "
     mem_str += memModule.inst+" (\n"+portlist.rstrip(",\n")+"\n);\n\n"
 
     return mem_str
@@ -89,92 +95,184 @@ def writeTBMemoryReadInstance(memModule):
     """
     wirelist = ""
     # Write wires
-    wirelist += "wire "+memModule.inst+"_dataarray_data_V_enb;\n"
+    wirelist += "wire "+memModule.inst+"_mem_V_enb;\n"
     wirelist += "wire["+str(6+memModule.bxbitwidth)+":0] "
-    wirelist += memModule.inst+"_dataarray_data_V_readaddr;\n"
+    wirelist += memModule.inst+"_mem_V_readaddr;\n"
     wirelist += "wire["+str(memModule.bitwidth-1)+":0] "
-    wirelist += memModule.inst+"_dataarray_data_V_dout;\n"
+    wirelist += memModule.inst+"_mem_V_dout;\n"
     for i in range(0,2**memModule.bxbitwidth):
         wirelist += "wire[6:0] "+memModule.inst+"_nentries_"+str(i)+"_V_dout;\n"
     return wirelist
 
-def writeTopLevelMemoryInstance(memModule, interface):
+def writeMemoryUtil(memDict, memInfoDict):
     """
-    # Declaration of memories & associated wires
+    # Produce VHDL package with utilities for memories that are specific
+    # to current chain.
+    # Inputs:
+    #   memDict = dictionary of memories organised by type 
+    #             & no. of bits (TPROJ_58b etc.)
+    #   memInfoDict = dictionary of info about each memory type.
+    """
+    ss = writeTopPreamble(False)
+    ss += "package memUtil_pkg is\n\n"
+
+    for mtypeB in memDict:
+        memInfo = memInfoDict[mtypeB]
+
+        memList = memDict[mtypeB]
+        # Sort with memories connected to top-level interface first.
+        # (This is needed so a VHDL enum of this subset can be a VHDL subtype
+        # of the enum of all the memories).
+        memList.sort(key=lambda m: int(m.is_initial or m.is_final), reverse=True)
+
+        # Define enum type listing all memory instances of this type.
+        enumName = "enum_"+mtypeB
+        ss += "  type "+enumName+" is ("
+        for mem in memList:
+            ss += mem.var()+","
+        ss = ss.rstrip(",")
+        ss += ");\n\n"
+        
+        """
+        # FIX: TO FINISH 
+        # For special case where only some memories of this type interface
+        # to top-level function, define enum subtype for them.
+        if memInfo.mixedIO:
+            varListExt = []
+            for mem in memList:
+                if mem.is_initial or mem.is_final:
+                    varListExt.append(mem.var())
+            assert(len(varListExt()) > 0)
+            enumName = "enumPartial_"+mtypeB
+            ss += "  subtype "+enumName+" is enum_"+mtypeB
+            ss += " range "+varList[0]
+            ss += " to "   +varList[-1]+";\n\n"        
+        """
+
+    # Define array types indexed by enums above used for signals connecting to memories.
+    for mtypeB in memInfoDict:
+        memInfo = memInfoDict[mtypeB]
+        enumName = "enum_"+mtypeB
+        mtype = mtypeB.split("_")[0]
+        bitwidth = int(mtypeB.split("_")[1]);
+        num_pages = 2**memInfo.bxbitwidth
+        
+        arrName = "t_arr_"+mtypeB+"_1b"
+        ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n" 
+
+        arrName = "t_arr_"+mtypeB+"_ADDR"
+        ss += "  type "+arrName+" is array("+enumName+") of std_logic_vector("+str(6+memInfo.bxbitwidth)+" downto 0);\n" 
+
+        arrName = "t_arr_"+mtypeB+"_DATA"
+        ss += "  type "+arrName+" is array("+enumName+") of std_logic_vector("+str(bitwidth-1)+" downto 0);\n" 
+
+        if memInfo.is_binned:
+            varStr = "_8_5b"
+        else:
+            varStr = "_7b"
+        arrName = "t_arr_"+mtypeB+"_NENT"
+        ss += "  type "+arrName+" is array("+enumName+") of t_arr"+str(num_pages)+varStr+";\n"
+
+    ss += "end package memUtil_pkg;\n"
+
+    return ss;
+
+def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
+    """
+    # Declaration of memories of type "mtype" (e.g. TPROJ) & associated wires
+    # Inputs:
+    #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
+    #   memList = list of memories of given type & bit width
+    #   memInfo = Info about each memory type (in MemTypeInfoByKey class)
     """
     wirelist = ""
     parameterlist = ""
     portlist = ""
     mem_str = ""
 
+    mtype = mtypeB.split("_")[0]
+    bitwidth = mtypeB.split("_")[1]
+
+    # Assume all memories of given type have same bxbitwidth.
+    bxbitwidth =  memInfo.bxbitwidth
+    num_pages = 2**bxbitwidth
+
+    interface = int(memInfo.is_final) - int(memInfo.is_initial)
+
     if interface == 1:
-        assert len(memModule.upstreams)==1
-        prevProcMod = memModule.upstreams[0]
-        sync_signal = prevProcMod.mtype+"_done"
+        assert memInfo.upstream_mtype_short != ""
+        sync_signal = memInfo.upstream_mtype_short+"_done"
     else:
-        assert len(memModule.downstreams)==1
-        nextProcMod = memModule.downstreams[0]
-        sync_signal = nextProcMod.mtype+"_start"
+        assert memInfo.downstream_mtype_short != ""
+        sync_signal = memInfo.downstream_mtype_short+"_start"
 
     # Write wires
-    if interface != -1:
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_wea       : std_logic;\n"
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_writeaddr : "
-        wirelist += "std_logic_vector("+str(6+memModule.bxbitwidth)+" downto 0);\n"
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_din       : "
-        wirelist += "std_logic_vector("+str(memModule.bitwidth-1)+" downto 0);\n"
+    if (interface != -1 and not extraports) or (interface == 1 and extraports):
+        wirelist += "  signal "+mtypeB+"_mem_A_wea          : "
+        wirelist += "t_arr_"+mtypeB+"_1b;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_writeaddr   : "
+        wirelist += "t_arr_"+mtypeB+"_ADDR;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_din         : "
+        wirelist += "t_arr_"+mtypeB+"_DATA;\n"
     if interface != 1:
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_enb      : std_logic;\n"
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_readaddr : "
-        wirelist += "std_logic_vector("+str(6+memModule.bxbitwidth)+" downto 0);\n"
-        wirelist += "  signal "+memModule.inst+"_dataarray_data_V_dout     : "
-        wirelist += "std_logic_vector("+str(memModule.bitwidth-1)+" downto 0);\n"
-        if memModule.has_numEntries_out:
-            num_pages = 2**memModule.bxbitwidth
-            if memModule.is_binned:
-                wirelist += "  signal "+memModule.inst+"_nentries_VVV_dout : "
-                wirelist += "t_arr"+str(num_pages)+"_8_5b; -- (#page)(#bin)\n"
+        wirelist += "  signal "+mtypeB+"_mem_A_enb          : "
+        wirelist += "t_arr_"+mtypeB+"_1b;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_readaddr    : "
+        wirelist += "t_arr_"+mtypeB+"_ADDR;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_dout        : "
+        wirelist += "t_arr_"+mtypeB+"_DATA;\n" 
+
+        if memInfo.has_numEntries_out:
+            if memInfo.is_binned:
+                wirelist += "  signal "+mtypeB+"_mem_AAAV_dout_nent : "
+                wirelist += "t_arr_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
             else:
-                wirelist += "  signal "+memModule.inst+"_nentries_VV_dout : "
-                wirelist += "t_arr"+str(num_pages)+"_7b; -- (#page)\n"
+                wirelist += "  signal "+mtypeB+"_mem_AAV_dout_nent  : "
+                wirelist += "t_arr_"+mtypeB+"_NENT; -- (#page)\n"
 
     # Write parameters
-    parameterlist += "      RAM_WIDTH       => "+str(memModule.bitwidth)+",\n"
-    parameterlist += "      NUM_PAGES       => "+str(2**memModule.bxbitwidth)+",\n"
-    parameterlist += "      INIT_FILE       => \"\",\n"
-    parameterlist += "      INIT_HEX        => true,\n"
-    parameterlist += "      RAM_PERFORMANCE => \"HIGH_PERFORMANCE\",\n"
+    parameterlist += "        RAM_WIDTH       => "+bitwidth+",\n"
+    parameterlist += "        NUM_PAGES       => "+str(num_pages)+",\n"
+    parameterlist += "        INIT_FILE       => \"\",\n"
+    parameterlist += "        INIT_HEX        => true,\n"
+    parameterlist += "        RAM_PERFORMANCE => \"HIGH_PERFORMANCE\",\n"
 
     # Write ports
-    portlist += "      clka      => clk,\n"
-    portlist += "      wea       => "+memModule.inst+"_dataarray_data_V_wea,\n"
-    portlist += "      addra     => "+memModule.inst+"_dataarray_data_V_writeaddr,\n"
-    portlist += "      dina      => "+memModule.inst+"_dataarray_data_V_din,\n"
-    portlist += "      clkb      => clk,\n"
-    portlist += "      enb       => "+memModule.inst+"_dataarray_data_V_enb,\n"
-    portlist += "      rstb      => '0',\n"
-    portlist += "      regceb    => '1',\n"
-    portlist += "      addrb     => "+memModule.inst+"_dataarray_data_V_readaddr,\n"
-    portlist += "      doutb     => "+memModule.inst+"_dataarray_data_V_dout,\n"
-    portlist += "      sync_nent => "+sync_signal+",\n"
+    portlist += "        clka      => clk,\n"
+    portlist += "        wea       => "+mtypeB+"_mem_A_wea(var),\n"
+    portlist += "        addra     => "+mtypeB+"_mem_AV_writeaddr(var),\n"
+    portlist += "        dina      => "+mtypeB+"_mem_AV_din(var),\n"
+    portlist += "        clkb      => clk,\n"
+    portlist += "        enb       => "+mtypeB+"_mem_A_enb(var),\n"
+    portlist += "        rstb      => '0',\n"
+    portlist += "        regceb    => '1',\n"
+    portlist += "        addrb     => "+mtypeB+"_mem_AV_readaddr(var),\n"
+    portlist += "        doutb     => "+mtypeB+"_mem_AV_dout(var),\n"
+    portlist += "        sync_nent => "+sync_signal+",\n"
 
-    if memModule.has_numEntries_out:
-        if memModule.is_binned:
-            portlist += "      nent_o    => "+memModule.inst+"_nentries_VVV_dout,\n"
+    if memList[0].has_numEntries_out:
+        if memList[0].is_binned:
+            portlist += "        nent_o    => "+mtypeB+"_mem_AAAV_dout_nent(var),\n"
         else:
-            portlist += "      nent_o    => "+memModule.inst+"_nentries_VV_dout,\n"
+            portlist += "        nent_o    => "+mtypeB+"_mem_AAV_dout_nent(var),\n"
     else:
-        portlist += "      nent_o    => open,\n"
+        portlist += "        nent_o    => open,\n"
 
-    if memModule.is_binned:
-        mem_str += "\n  "+memModule.inst+" : entity work.tf_mem_bin"
+    enum_type = "enum_"+mtypeB
+    genName = mtypeB+"_loop"
+    mem_str += "  "+genName+" : for var in "+enum_type+" generate\n"
+    mem_str += "  begin\n\n"
+    if memList[0].is_binned:
+        mem_str += "    "+mtypeB+" : entity work.tf_mem_bin\n"
     else:
-        mem_str += "\n  "+memModule.inst+" : entity work.tf_mem"        
-    mem_str += "\n    generic map (\n"+parameterlist.rstrip(",\n")+"\n    )"
-    mem_str += "\n    port map (\n"+portlist.rstrip(",\n")+"\n  );\n\n"
+        mem_str += "    "+mtypeB+" : entity work.tf_mem\n"        
+    mem_str += "      generic map (\n"+parameterlist.rstrip(",\n")+"\n      )\n"
+    mem_str += "      port map (\n"+portlist.rstrip(",\n")+"\n      );\n\n"
+    mem_str += "  end generate "+genName+";\n\n\n"
+
     return wirelist,mem_str
 
-def writeControlSignals_interface(initial_proc, final_proc):
+def writeControlSignals_interface(initial_proc, final_proc, notfinal_procs):
     """
     # Top-level interface: control signals
     """
@@ -182,43 +280,60 @@ def writeControlSignals_interface(initial_proc, final_proc):
     string_ctrl_signals += "    clk        : in std_logic;\n"
     string_ctrl_signals += "    reset      : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_start  : in std_logic;\n"
-    string_ctrl_signals += "    bx_in_"+initial_proc+" : in std_logic_vector(2 downto 0);\n"
-    string_ctrl_signals += "    bx_out_"+final_proc+" : out std_logic_vector(2 downto 0);\n"
-    string_ctrl_signals += "    bx_out_"+final_proc+"_vld : out std_logic;\n"
+    string_ctrl_signals += "    "+initial_proc+"_bx_in : in std_logic_vector(2 downto 0);\n"
+    string_ctrl_signals += "    "+final_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
+    string_ctrl_signals += "    "+final_proc+"_bx_out_vld : out std_logic;\n"
     string_ctrl_signals += "    "+final_proc+"_done   : out std_logic;\n"
+    # Extra output ports if debug info must be sent to test-bench.
+    for mid_proc in notfinal_procs:
+        string_ctrl_signals += "    "+mid_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
+        string_ctrl_signals += "    "+mid_proc+"_bx_out_vld : out std_logic;\n"
+        string_ctrl_signals += "    "+mid_proc+"_done   : out std_logic;\n"
+
     return string_ctrl_signals
 
-def writeMemoryLHSPorts_interface(memModule):
+def writeMemoryLHSPorts_interface(mtypeB, extraports=False):
     """
     # Top-level interface: input memories' ports.
     """
+
+    if (extraports):
+        direction = "out" # carry debug info to test-bench
+    else:
+        direction = "in"
+
     string_input_mems = ""
-    string_input_mems += "    "+memModule.inst+"_dataarray_data_V_wea       : in std_logic;\n"
-    string_input_mems += "    "+memModule.inst+"_dataarray_data_V_writeaddr : in std_logic_vector("
-    string_input_mems += str(6+memModule.bxbitwidth)+" downto 0);\n"
-    string_input_mems += "    "+memModule.inst+"_dataarray_data_V_din       : in std_logic_vector("
-    string_input_mems += str(memModule.bitwidth-1)+" downto 0);\n"
+    string_input_mems += "    "+mtypeB+"_mem_A_wea        : "+direction+" t_arr_"+mtypeB+"_1b;\n"
+    string_input_mems += "    "+mtypeB+"_mem_AV_writeaddr : "+direction+" t_arr_"+mtypeB+"_ADDR;\n"
+    string_input_mems += "    "+mtypeB+"_mem_AV_din       : "+direction+" t_arr_"+mtypeB+"_DATA;\n"
+
     return string_input_mems
 
-def writeMemoryRHSPorts_interface(memModule):
+def writeMemoryRHSPorts_interface(mtypeB, memList, memInfo):
     """
     # Top-level interface: output memories' ports.
+    # Inputs:
+    #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
+    #   memList = list of memories of given type & bit width
+    #   memInfo = Info about each memory type (in MemTypeInfoByKey class)
     """
-    string_output_mems = ""
-    string_output_mems += "    "+memModule.inst+"_dataarray_data_V_enb      : in std_logic;\n"
-    string_output_mems += "    "+memModule.inst+"_dataarray_data_V_readaddr : in std_logic_vector("
-    string_output_mems += str(6+memModule.bxbitwidth)+" downto 0);\n"
-    string_output_mems += "    "+memModule.inst+"_dataarray_data_V_dout     : out std_logic_vector("
-    string_output_mems += str(memModule.bitwidth-1)+" downto 0);\n"
 
-    if memModule.has_numEntries_out:
-        num_pages = 2**memModule.bxbitwidth
-        if memModule.is_binned:
-            string_output_mems += "    "+memModule.inst+"_nentries_VVV_dout : "
-            string_output_mems += "out t_arr"+str(num_pages)+"_8_5b;\n"
+    # Assume all memories of given type have same bxbitwidth.
+    bxbitwidth =  memInfo.bxbitwidth
+
+    string_output_mems = ""
+    string_output_mems += "    "+mtypeB+"_mem_A_enb          : in t_arr_"+mtypeB+"_1b;\n"
+    string_output_mems += "    "+mtypeB+"_mem_AV_readaddr    : in t_arr_"+mtypeB+"_ADDR;\n"
+    string_output_mems += "    "+mtypeB+"_mem_AV_dout        : out t_arr_"+mtypeB+"_DATA;\n"
+
+    if memInfo.has_numEntries_out:
+        num_pages = 2**bxbitwidth
+        if memInfo.is_binned:
+            string_output_mems += "    "+mtypeB+"_mem_AAAV_dout_nent : "
+            string_output_mems += "out t_arr_"+mtypeB+"_NENT;\n"
         else:
-            string_output_mems += "    "+memModule.inst+"_nentries_VV_dout : "
-            string_output_mems += "out t_arr"+str(num_pages)+"_7b;\n"
+            string_output_mems += "    "+mtypeB+"_mem_AAV_dout_nent  : "
+            string_output_mems += "out t_arr_"+mtypeB+"_NENT;\n" 
 
     return string_output_mems
 
@@ -279,11 +394,11 @@ def writeFWBlockMemoryLHSPorts(memModule):
     # Verilog test bench: send memories to top-level.
     """
     string_input_mems = ""
-    string_input_mems += "  ."+memModule.inst+"_dataarray_data_V_wea(1'b1),\n"
-    string_input_mems += "  ."+memModule.inst+"_dataarray_data_V_writeaddr("
-    string_input_mems += memModule.inst+"_dataarray_data_V_writeaddr),\n"
-    string_input_mems += "  ."+memModule.inst+"_dataarray_data_V_din("
-    string_input_mems += memModule.inst+"_dataarray_data_V_dout),\n"
+    string_input_mems += "  ."+memModule.inst+"_mem_A_wea(1'b1),\n"
+    string_input_mems += "  ."+memModule.inst+"_mem_AV_writeaddr("
+    string_input_mems += memModule.inst+"_mem_V_writeaddr),\n"
+    string_input_mems += "  ."+memModule.inst+"_mem_AV_din("
+    string_input_mems += memModule.inst+"_mem_V_dout),\n"
 
     return string_input_mems
 
@@ -292,20 +407,20 @@ def writeFWBlockMemoryRHSPorts(memModule):
     # Verilog test bench: returned memories from top-level.
     """
     string_output_mems = ""
-    string_output_mems += "  ."+memModule.inst+"_dataarray_data_V_enb("
-    string_output_mems += memModule.inst+"_dataarray_data_V_enb),\n"
-    string_output_mems += "  ."+memModule.inst+"_dataarray_data_V_readaddr("
-    string_output_mems += memModule.inst+"_dataarray_data_V_readaddr),\n"
-    string_output_mems += "  ."+memModule.inst+"_dataarray_data_V_dout("
-    string_output_mems += memModule.inst+"_dataarray_data_V_dout),\n"
+    string_output_mems += "  ."+memModule.inst+"_mem_A_enb("
+    string_output_mems += memModule.inst+"_mem_A_enb),\n"
+    string_output_mems += "  ."+memModule.inst+"_mem_AV_readaddr("
+    string_output_mems += memModule.inst+"_mem_AV_readaddr),\n"
+    string_output_mems += "  ."+memModule.inst+"_mem_AV_dout("
+    string_output_mems += memModule.inst+"_mem_AV_dout),\n"
     if memModule.has_numEntries_out:
         for i in range(0,2**memModule.bxbitwidth):
             if memModule.is_binned:
-                string_output_mems += "  ."+memModule.inst+"_nentries_"+str(i)+"_VV_dout("
-                string_output_mems += memModule.inst+"_nentries_"+str(i)+"_VV_dout),\n"
+                string_output_mems += "  ."+memModule.inst+"_mem_"+str(i)+"_AAAV_dout_nent("
+                string_output_mems += memModule.inst+"_mem_"+str(i)+"_AAAV_dout_nent),\n"
             else:
-                string_output_mems += "  ."+memModule.inst+"_nentries_"+str(i)+"_V_dout("
-                string_output_mems += memModule.inst+"_nentries_"+str(i)+"_V_dout),\n"
+                string_output_mems += "  ."+memModule.inst+"_mem_"+str(i)+"_AAV_dout_nent("
+                string_output_mems += memModule.inst+"_mem_"+str(i)+"_AAV_dout_nent),\n"
 
     return string_output_mems
 
@@ -322,21 +437,28 @@ def writeProcCombination(module, str_ctrl_func, special_TC, templpars_str, str_p
 
     return module_str
 
-def writeStartSwitchAndInternalBX(module,mem):
+def writeStartSwitchAndInternalBX(module,mem,extraports=False):
     """
     # Top-level: control (start/done) & Bx signals for use by given module
+    # Inputs: processing module & memory that is downstream of it.
     """
-    int_ctrl_wire = ""
-    int_ctrl_wire += "  signal "+module.mtype+"_done : std_logic := '0';\n"
-    int_ctrl_wire += "  signal "+mem.downstreams[0].mtype+"_start : std_logic := '0';\n"
-    int_ctrl_wire += "  signal bx_out_"+module.mtype+" : std_logic_vector(2 downto 0);\n"
-    int_ctrl_wire += "  signal bx_out_"+module.mtype+"_vld : std_logic;\n"
+    mtype = module.mtype_short()
+    mtype_down = mem.downstreams[0].mtype_short()
 
+    int_ctrl_wire = ""
+    if not extraports: 
+        int_ctrl_wire += "  signal "+mtype+"_done : std_logic := '0';\n"
+        int_ctrl_wire += "  signal "+mtype+"_bx_out : std_logic_vector(2 downto 0);\n"
+        int_ctrl_wire += "  signal "+mtype+"_bx_out_vld : std_logic;\n"
+    int_ctrl_wire += "  signal "+mtype_down+"_start : std_logic := '0';\n"
 
     int_ctrl_func = ""
-    int_ctrl_func += "  process("+module.mtype+"_done)\n  begin\n"
-    int_ctrl_func += "    if "+module.mtype+"_done = '1' then "
-    int_ctrl_func += mem.downstreams[0].mtype+"_start <= '1'; end if;\n  end process;\n\n"
+    int_ctrl_func += "  p_"+mtype_down+"_start : process(clk)\n  begin\n"
+    int_ctrl_func += "    if rising_edge(clk) then\n"
+    int_ctrl_func += "      if "+mtype+"_done = '1' then\n"
+    int_ctrl_func += "        "+mtype_down+"_start <= '1';\n"
+    int_ctrl_func += "      end if;\n    end if;\n"
+    int_ctrl_func += "  end process;\n\n"
 
     return int_ctrl_wire,int_ctrl_func
 
@@ -347,11 +469,11 @@ def writeProcControlSignalPorts(module,first_of_type):
     string_ctrl_ports = ""
     string_ctrl_ports += "      ap_clk   => clk,\n"
     string_ctrl_ports += "      ap_rst   => reset,\n"
-    string_ctrl_ports += "      ap_start => "+module.mtype+"_start,\n"
+    string_ctrl_ports += "      ap_start => "+module.mtype_short()+"_start,\n"
     string_ctrl_ports += "      ap_idle  => open,\n"
     string_ctrl_ports += "      ap_ready => open,\n"
     if first_of_type:
-        string_ctrl_ports += "      ap_done  => "+module.mtype+"_done,\n"
+        string_ctrl_ports += "      ap_done  => "+module.mtype_short()+"_done,\n"
     else:
         string_ctrl_ports += "      ap_done  => open,\n"
 
@@ -363,49 +485,49 @@ def writeProcBXPort(modName,isInput,isInitial):
     """
     bx_str = ""
     if isInput and isInitial:
-        bx_str += "      bx_V          => bx_in_"+modName+",\n"
+        bx_str += "      bx_V          => "+modName+"_bx_in,\n"
     elif isInput and not isInitial:
-        bx_str += "      bx_V          => bx_out_"+modName+",\n"
+        bx_str += "      bx_V          => "+modName+"_bx_out,\n"
     elif not isInput:
-        bx_str += "      bx_o_V        => bx_out_"+modName+",\n"
-        bx_str += "      bx_o_V_ap_vld => bx_out_"+modName+"_vld,\n"
+        bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
+        bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
     return bx_str
 
-def writeProcMemoryLHSPorts(argname,memory):
+def writeProcMemoryLHSPorts(argname,mem):
     """
     # Processing module port assignment: outputs to memories
     """
     string_mem_ports = ""
     string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_wea,\n"
+    string_mem_ports += mem.keyName()+"_mem_A_wea("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_writeaddr,\n"
+    string_mem_ports += mem.keyName()+"_mem_AV_writeaddr("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_d0        => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_din,\n"
+    string_mem_ports += mem.keyName()+"_mem_AV_din("+mem.var()+"),\n"
 
     return string_mem_ports
 
-def writeProcMemoryRHSPorts(argname,memory):
+def writeProcMemoryRHSPorts(argname,mem):
     """
     # Processing module port assignment: inputs from memories
     """
     string_mem_ports = ""
     string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_enb,\n"
+    string_mem_ports += mem.keyName()+"_mem_A_enb("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_readaddr,\n"
+    string_mem_ports += mem.keyName()+"_mem_AV_readaddr("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_dataarray_data_V_q0        => "
-    string_mem_ports += memory.inst+"_dataarray_data_V_dout,\n"
+    string_mem_ports += mem.keyName()+"_mem_AV_dout("+mem.var()+"),\n"
 
-    if memory.has_numEntries_out:
-        for i in range(0,2**memory.bxbitwidth):
-            if memory.is_binned:
+    if mem.has_numEntries_out:
+        for i in range(0,2**mem.bxbitwidth):
+            if mem.is_binned:
                 for j in range(0,8):
                     string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V_"+str(j)+"     => "
-                    string_mem_ports += memory.inst+"_nentries_VVV_dout("+str(i)+")("+str(j)+"),\n"
+                    string_mem_ports += mem.keyName()+"_mem_AAAV_dout_nent("+mem.var()+")("+str(i)+")("+str(j)+"),\n"
             else:
                 string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
-                string_mem_ports += memory.inst+"_nentries_VV_dout("+str(i)+"),\n"
+                string_mem_ports += mem.keyName()+"_mem_AAV_dout_nent("+mem.var()+")("+str(i)+"),\n"
 
     return string_mem_ports

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -121,8 +121,10 @@ def writeMemoryUtil(memDict, memInfoDict):
 
         memList = memDict[mtypeB]
         # Sort with memories connected to top-level interface first.
-        # (This is needed so a VHDL enum of this subset can be a VHDL subtype
-        # of the enum of all the memories).
+        # (This required only for special case, where only a subset of
+        # memories of given type are interfaced to top-level function. 
+        # It allows a VHDL enum of this subset to be a VHDL subtype of the 
+        # enum of all memories of this type).
         memList.sort(key=lambda m: int(m.is_initial or m.is_final), reverse=True)
 
         # Define enum type listing all memory instances of this type.
@@ -134,9 +136,10 @@ def writeMemoryUtil(memDict, memInfoDict):
         ss += ");\n\n"
         
         """
-        # FIX: TO FINISH 
-        # For special case where only some memories of this type interface
-        # to top-level function, define enum subtype for them.
+        # FIX IF NEEDED: 
+        # Needed only for special case where only a subset of memories of
+        # given type are interfaced to top-level function. 
+        # Define enum subtype for them.
         if memInfo.mixedIO:
             varListExt = []
             for mem in memList:

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -117,7 +117,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
             string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
         elif memList[-1].is_final:
             # Output arguments
-            string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memList, memInfo)
+            string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(mtypeB, extraports)            

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -38,7 +38,7 @@ def writeMemoryModules(mem_list, interface=0):
     string_wires = ""
     string_mem = ""
     # Loop over memories in the list
-    for memModule in sorted(mem_list,key=lambda x: x.index):
+    for memModule in mem_list:
         string_wires_inst, string_mem_inst = writeTopLevelMemoryInstance(memModule,interface)
         string_wires += string_wires_inst
         string_mem += string_mem_inst
@@ -61,9 +61,6 @@ def writeProcModules(proc_list, hls_src_dir):
     # List to keep track of whether current instance of modules is first of its type
     # (needed for things like routing bx ports, done signals, etc.)
     proc_type_list = []
-
-    # Sort the processing module list
-    proc_list.sort(key=lambda x: x.index)
 
     for aProcMod in proc_list:
         if not aProcMod.mtype in proc_type_list: # Is this aProcMod the first of its type
@@ -413,6 +410,10 @@ if __name__ == "__main__":
         uutProcModule = tracklet.get_proc_module(args.uut)
         process_list, memory_list = TrackletGraph.get_slice_around_proc(
             uutProcModule, args.nupstream, args.ndownstream) 
+
+    # Sort the module lists by order in which they appear in chain.
+    process_list.sort(key=lambda x: x.index)
+    memory_list.sort(key=lambda x: x.index)
 
     for mem in memory_list:
         # Get widths of all needed memories

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -419,9 +419,6 @@ if __name__ == "__main__":
     process_list.sort(key=lambda x: x.index)
     memory_list.sort(key=lambda x: x.index)
 
-    # Sort memory list with input memories first & output ones last.
-    memory_list.sort(key=lambda x: int(x.is_final) - int(x.is_initial))
-
     for mem in memory_list:
         # Get widths of all needed memories
         TrackletGraph.populate_bitwidths(mem,args.hls_dir)
@@ -448,8 +445,7 @@ if __name__ == "__main__":
     pageWidth, pageHeight, dyBox, textSize = tracklet.draw_graph(process_list)
     ROOT.gROOT.SetBatch(True)
     ROOT.gROOT.LoadMacro('DrawTrackletProject.C')
-    #IRT
-    #ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize);
+    ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize);
 
 
     ###############

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -29,7 +29,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports):
     # Inputs:
     #   memDict = dictionary of memories organised by type 
     #             & no. of bits (TPROJ_58b etc.)
-    #   memInfoDict = dictionary of info about each memory type.
+    #   memInfoDict = dictionary of info (MemTypeInfoByKey) about each memory type.
     """
     string_wires = ""
     string_mem = ""
@@ -83,7 +83,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
     #                  generate the bx signals. Seems a bit wasteful to pass the whole list)
     # memDict:         dictionary of memories organised by type 
     #                  & no. of bits (TPROJ_58b etc.)
-    # memInfoDict:     dictionary of info about each memory type.
+    # memInfoDict:     dictionary of info (MemTypeInfoByKey) about each memory type.
     # streamIO:        controls whether the input to this firmware block is an hls::stream, rather
     #                  than a BRAM interface. This will be needed when the first processing block in the
     #                  chain is input router, and might be needed for the KF. Not yet implemented.
@@ -112,10 +112,10 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
     for mtypeB in memDict:
         memList = memDict[mtypeB]
         memInfo = memInfoDict[mtypeB]
-        if memList[0].is_initial:
+        if memInfo.is_initial:
             # Input arguments
             string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
-        elif memList[-1].is_final:
+        elif memInfo.is_final:
             # Output arguments
             string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)
         elif extraports:
@@ -137,7 +137,7 @@ def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraport
     # Inputs:
     #   memDict = dictionary of memories organised by type 
     #             & no. of bits (TPROJ_58b etc.)
-    #   memInfoDict = dictionary of info about each memory type.
+    #   memInfoDict = dictionary of info (MemTypeInfoByKey) about each memory type.
     """
     
     # Write memories
@@ -229,7 +229,7 @@ def writeTestBench(topfunc, memDict, memInfoDict, emData_dir, sector="04"):
     # Inputs:
     #   memDict = dictionary of memories organised by type 
     #             & no. of bits (TPROJ_58b etc.)
-    #   memInfoDict = dictionary of info about each memory type.
+    #   memInfoDict = dictionary of info (MemTypeInfoByKey) about each memory type.
     #   emData_dir =   directory where data for input memories is stored
     #   sector =       which sector nonant the emData is taken from
     """


### PR DESCRIPTION
Top-level VHDL written by scripts now:
1) Instantiates all memories of given type & bit-width within the nonant in a "generate" loop.
2) Instantiates all signals in nonant connected to memories of given type & bit-width as an array, where array is indexed by enum. The definitions of these arrays and enums is written to a VHDL package memUtil_pkg.vhd.
3) Adds option "-x" to generate_hdl.py, which causes top-level VHDL to have additional output ports giving data of intermediate memories in chain.

N.B. The top-level VHDL written by the updated scripts in this PR and the updated VHDL test-bench they require can be found in https://github.com/cms-L1TK/firmware-hls/pull/144 .