### PR TITLE
Update memory bit widths

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -179,16 +179,16 @@ class TrackletGraph(object):
             if barrel2S>-1: mem.bitwidth = 58
             if disk>-1: mem.bitwidth = 59
         elif mem.mtype == "VMProjections":
-            if barrelPS>-1 or barrel2S>-1: mem.bitwidth = 21
-            if disk>-1: mem.bitwidth = 21
+            if barrelPS>-1 or barrel2S>-1: mem.bitwidth = 24
+            if disk>-1: mem.bitwidth = 24
         elif mem.mtype == "VMStubsME":
-            if barrelPS>-1: mem.bitwidth = 13
-            if barrel2S>-1 or disk>-1: mem.bitwidth = 14
+            if barrelPS>-1: mem.bitwidth = 16
+            if barrel2S>-1 or disk>-1: mem.bitwidth = 17
         elif mem.mtype == "CandidateMatch":
             mem.bitwidth = 14
         elif mem.mtype == "FullMatch":
-            if barrelPS>-1 or barrel2S>-1: mem.bitwidth = 45
-            if disk>-1: mem.bitwidth = 43
+            if barrelPS>-1 or barrel2S>-1: mem.bitwidth = 52
+            if disk>-1: mem.bitwidth = 55
         else:
             raise ValueError("Bitwidth undefined for "+mem.mtype)
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -454,13 +454,7 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False):
         int_ctrl_wire += "  signal "+mtype+"_bx_out_vld : std_logic;\n"
     int_ctrl_wire += "  signal "+mtype_down+"_start : std_logic := '0';\n"
 
-    int_ctrl_func = ""
-    int_ctrl_func += "  p_"+mtype_down+"_start : process(clk)\n  begin\n"
-    int_ctrl_func += "    if rising_edge(clk) then\n"
-    int_ctrl_func += "      if "+mtype+"_done = '1' then\n"
-    int_ctrl_func += "        "+mtype_down+"_start <= '1';\n"
-    int_ctrl_func += "      end if;\n    end if;\n"
-    int_ctrl_func += "  end process;\n\n"
+    int_ctrl_func = "  "+mtype_down+"_start <= '1' when "+mtype+"_done = '1';\n\n"
 
     return int_ctrl_wire,int_ctrl_func
 


### PR DESCRIPTION
1) Andrew had updated the memory bit widths in SectorProcessor*.vhd, during the FW sync, but had not yet made the corresponding change to the python scripts that generate this file. This fix addresses that.
2) This fix also removes the 1 clock delay in generating the "start" signals in SectorProcessor*.vhd, which we were concerned about. But this doesn't affect discrepancies.