### PR TITLE
IR-VMR Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Basic instructions to run the project generation for the Vivado HLS project with
       
       ./generator_hdl.py (dirHLS) --uut TC_L1L2E -u 1 -d 0
 
-  *dirHLS* is the location of the HLS code, which defaults to "../firmware-hls".
+      example for IRVMR chain:
+
+      generator_hdl.py --uut VMR_L2PHIA -u 1 -d 0
+
+	*dirHLS* is the location of the HLS code, which defaults to "../firmware-hls".
 
   (Script *generator_vhls.py* is abandoned attempt at using HLS for top-level).
 

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -1,4 +1,5 @@
 import re
+import math
 
 #######################################
 # Ordering of the processing steps
@@ -878,8 +879,8 @@ class TrackletGraph(object):
         # Return canvas size in pixels along X and Y
         pageWidth = 10000
         pageHeight = 5000
-        dyBox = 0.5/(maxnum+1)
-        textSize = 0.5/(maxnum+10)
+        dyBox = 0.5/(math.log(maxnum)*10)
+        textSize = 0.5/(math.log(maxnum)*10+1)
 
-        #print  pageWidth, pageHeight, dyBox, textSize
+        # print  pageWidth, pageHeight, dyBox, textSize, maxnum
         return int(pageWidth), int(pageHeight), dyBox, textSize

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -101,9 +101,10 @@ class MemTypeInfoByKey(object):
         self.bxbitwidth = memList[0].bxbitwidth
         self.is_binned  = memList[0].is_binned
         self.has_numEntries_out = memList[0].has_numEntries_out
-        # At least one memory of this type is initial or final.
+        # At least one memory of this type is initial.
         self.is_initial = any(m.is_initial for m in memList)
-        self.is_final   = any(m.is_final for m in memList)
+        # All memories of this type is final.
+        self.is_final   = all(m.is_final for m in memList)
         assert(not (self.is_initial and self.is_final))
         # Short type name of any upstream/downstream processing module.
         self.upstream_mtype_short   = ""
@@ -121,9 +122,9 @@ class MemTypeInfoByKey(object):
             if (self.is_initial and not m.is_initial) or (self.is_final and not m.is_final):
                 self.mixedIO = True
         assert(len(keySet) == 1) # Ensure only one key name is input memory list.
-        # if self.mixedIO:
-        #     print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
-        #     exit(1)
+        if self.mixedIO and self.is_initial:
+            print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some inputs connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
+            exit(1)
 
 
 #######################################

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -116,7 +116,7 @@ class MemTypeInfoByKey(object):
             keySet.add(m.keyName())
             if m.upstreams[0] is not None:
                 self.upstream_mtype_short = m.upstreams[0].mtype_short()
-            if m.upstreams[0] is not None:
+            if m.downstreams[0] is not None:
                 self.downstream_mtype_short = m.downstreams[0].mtype_short()
             if (self.is_initial and not m.is_initial) or (self.is_final and not m.is_final):
                 self.mixedIO = True
@@ -169,10 +169,10 @@ class TrackletGraph(object):
         disk = -1
         for item in diskList:
             disk = max(disk,mem.inst.find(item))
-        if mem.mtype == "VMStubsTEInner":  #FIXME
-            mem.bitwidth = 22 if mem.inst.find("L1") else 16
+        if mem.mtype == "VMStubsTEInner":
+            mem.bitwidth = 23 if mem.inst.find("L5") else 22
         elif mem.mtype == "VMStubsTEOuter":
-            mem.bitwidth = 16
+            mem.bitwidth = 16 if (mem.inst.find("L4") or mem.inst.find("L6")) else mem.bitwidth = 17
         elif mem.mtype == "AllStubs" or mem.mtype == "InputLink" or mem.mtype == "DTCLink":
             mem.bitwidth = 36
         elif mem.mtype == "StubPairs":

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -16,12 +16,12 @@ import re
 # TODO: Should be able to generate this from the wiring
 #######################################
 # Drawing parameters
-ModuleDrawWidth_dict = {'DTCLink':3.0,
-                        'InputLink':3.0,
+ModuleDrawWidth_dict = {'DTCLink':2.0,
+                        'InputLink':2.0,
                         'VMStubsTEInner':3.0,
                         'VMStubsTEOuter':3.0,
                         'VMStubsME':3.0,
-                        'AllStubs':2.5,
+                        'AllStubs':3.0,
                         'StubPairs':4.0,
                         'TrackletParameters':3.0,
                         'TrackletProjections':4.0,
@@ -872,19 +872,12 @@ class TrackletGraph(object):
         fo.close()
 
         # FIXME
-        # Return canvas size in pixels along X and Y
-        pageHeight = (maxnum+1)*40
-        #width = sum(columns_width)*85
-        pageWidth =  pageHeight * 2
-        dyBox = 0.5/(maxnum+1)
-        textSize = 0.5/(maxnum+1)
-        
-        #print  width, height, dy, textsize
-        
         # Work In Progress - adjusts sizes in TrackletProject.pdf
+        # Return canvas size in pixels along X and Y
         pageWidth = 10000
         pageHeight = 5000
-        dyBox = 0.025
-        textSize = 0.015
-        
+        dyBox = 0.5/(maxnum+1)
+        textSize = 0.5/(maxnum+10)
+
+        #print  pageWidth, pageHeight, dyBox, textSize
         return int(pageWidth), int(pageHeight), dyBox, textSize

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -171,9 +171,11 @@ class TrackletGraph(object):
         for item in diskList:
             disk = max(disk,mem.inst.find(item))
         if mem.mtype == "VMStubsTEInner":
-            mem.bitwidth = 23 if mem.inst.find("L5") else 22
+            if mem.inst.find("L5")>-1: mem.bitwidth = 23 
+            else: mem.bitwidth = 22
         elif mem.mtype == "VMStubsTEOuter":
-            mem.bitwidth = 16 if (mem.inst.find("L4") or mem.inst.find("L6")) else mem.bitwidth = 17
+            if (mem.inst.find("L4")>-1 or mem.inst.find("L6")>-1): mem.bitwidth = 17
+            else: mem.bitwidth = 16
         elif mem.mtype == "AllStubs" or mem.mtype == "InputLink":
             mem.bitwidth = 36
         elif mem.mtype == "DTCLink":

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -171,7 +171,7 @@ class TrackletGraph(object):
             mem.bitwidth = 22 if mem.inst.find("L1") else 16
         elif mem.mtype == "VMStubsTEOuter":
             mem.bitwidth = 16
-        elif mem.mtype == "AllStubs":
+        elif mem.mtype == "AllStubs" or mem.mtype == "InputLink":
             mem.bitwidth = 36
         elif mem.mtype == "StubPairs":
             mem.bitwidth = 14
@@ -201,7 +201,8 @@ class TrackletGraph(object):
                   or mem.mtype == "StubPairs" or mem.mtype == "VMStubsTEInner" or mem.mtype == "VMStubsTEOuter"):
             mem.bxbitwidth = 1
         elif (    mem.mtype == "AllProj" or mem.mtype == "VMStubsME"
-               or mem.mtype == "AllStubs" or mem.mtype == "TrackletParameters"):
+               or mem.mtype == "AllStubs" or mem.mtype == "TrackletParameters"
+               or mem.mtype == "InputLink"):
             mem.bxbitwidth = 3
         else:
             raise ValueError("Bxbitwidth undefined for "+mem.mtype)

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -16,7 +16,8 @@ import re
 # TODO: Should be able to generate this from the wiring
 #######################################
 # Drawing parameters
-ModuleDrawWidth_dict = {'InputLink':3.0,
+ModuleDrawWidth_dict = {'DTCLink':3.0,
+                        'InputLink':3.0,
                         'VMStubsTEInner':3.0,
                         'VMStubsTEOuter':3.0,
                         'VMStubsME':3.0,
@@ -31,6 +32,7 @@ ModuleDrawWidth_dict = {'InputLink':3.0,
                         'TrackFit':2.5,
                         'CleanTrack':2.5,
                         ###################
+                        'InputRouter':2.0,
                         'VMRouter':2.0,
                         'TrackletEngine':4.0,
                         'TrackletCalculator':2.5,
@@ -171,7 +173,7 @@ class TrackletGraph(object):
             mem.bitwidth = 22 if mem.inst.find("L1") else 16
         elif mem.mtype == "VMStubsTEOuter":
             mem.bitwidth = 16
-        elif mem.mtype == "AllStubs" or mem.mtype == "InputLink":
+        elif mem.mtype == "AllStubs" or mem.mtype == "InputLink" or mem.mtype == "DTCLink":
             mem.bitwidth = 36
         elif mem.mtype == "StubPairs":
             mem.bitwidth = 14
@@ -198,11 +200,11 @@ class TrackletGraph(object):
         # Populate BX bit width
         if (      mem.mtype == "TrackletProjections" or mem.mtype == "VMProjections"
                or mem.mtype == "CandidateMatch" or mem.mtype == "FullMatch"
-                  or mem.mtype == "StubPairs" or mem.mtype == "VMStubsTEInner" or mem.mtype == "VMStubsTEOuter"):
+               or mem.mtype == "StubPairs" or mem.mtype == "VMStubsTEInner" or mem.mtype == "VMStubsTEOuter"
+               or mem.mtype == "InputLink" or mem.mtype == "DTCLink"):
             mem.bxbitwidth = 1
         elif (    mem.mtype == "AllProj" or mem.mtype == "VMStubsME"
-               or mem.mtype == "AllStubs" or mem.mtype == "TrackletParameters"
-               or mem.mtype == "InputLink"):
+               or mem.mtype == "AllStubs" or mem.mtype == "TrackletParameters"):
             mem.bxbitwidth = 3
         else:
             raise ValueError("Bxbitwidth undefined for "+mem.mtype)
@@ -324,6 +326,11 @@ class TrackletGraph(object):
                 if barrelseed.search(mem_inst):
                     isbarrel = True
                 if diskseed.search(mem_inst):
+                    isdisk = True
+            elif mem_type in ['DTCLink']: # WHAT DO I DO WITH THIS
+                if barrelstr.search(mem_inst):
+                    isbarrel = True
+                if diskstr.search(mem_inst):
                     isdisk = True
             else:
                 raise ValueError("Unknown memory type: "+mem_type)

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -114,9 +114,9 @@ class MemTypeInfoByKey(object):
         keySet = set()
         for m in memList:
             keySet.add(m.keyName())
-            if len(m.upstreams) > 0:
+            if m.upstreams[0] is not None:
                 self.upstream_mtype_short = m.upstreams[0].mtype_short()
-            if len(m.downstreams) > 0:
+            if m.upstreams[0] is not None:
                 self.downstream_mtype_short = m.downstreams[0].mtype_short()
             if (self.is_initial and not m.is_initial) or (self.is_final and not m.is_final):
                 self.mixedIO = True

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -330,7 +330,7 @@ class TrackletGraph(object):
                     isbarrel = True
                 if diskseed.search(mem_inst):
                     isdisk = True
-            elif mem_type in ['DTCLink']: # DTCLinks are not memories
+            elif mem_type in ['DTCLink']: # DTCLinks are technically not memories
                 if barrelstr.search(mem_inst):
                     isbarrel = True
                 if diskstr.search(mem_inst):

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -121,9 +121,9 @@ class MemTypeInfoByKey(object):
             if (self.is_initial and not m.is_initial) or (self.is_final and not m.is_final):
                 self.mixedIO = True
         assert(len(keySet) == 1) # Ensure only one key name is input memory list.
-        if self.mixedIO:
-            print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
-            exit(1)
+        # if self.mixedIO:
+        #     print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
+        #     exit(1)
 
 
 #######################################
@@ -173,8 +173,10 @@ class TrackletGraph(object):
             mem.bitwidth = 23 if mem.inst.find("L5") else 22
         elif mem.mtype == "VMStubsTEOuter":
             mem.bitwidth = 16 if (mem.inst.find("L4") or mem.inst.find("L6")) else mem.bitwidth = 17
-        elif mem.mtype == "AllStubs" or mem.mtype == "InputLink" or mem.mtype == "DTCLink":
+        elif mem.mtype == "AllStubs" or mem.mtype == "InputLink":
             mem.bitwidth = 36
+        elif mem.mtype == "DTCLink":
+            mem.bitwidth = 39
         elif mem.mtype == "StubPairs":
             mem.bitwidth = 14
         elif mem.mtype == "TrackletParameters":
@@ -327,11 +329,12 @@ class TrackletGraph(object):
                     isbarrel = True
                 if diskseed.search(mem_inst):
                     isdisk = True
-            elif mem_type in ['DTCLink']: # WHAT DO I DO WITH THIS
+            elif mem_type in ['DTCLink']: # DTCLinks are not memories
                 if barrelstr.search(mem_inst):
                     isbarrel = True
                 if diskstr.search(mem_inst):
                     isdisk = True
+                #continue
             else:
                 raise ValueError("Unknown memory type: "+mem_type)
 

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -273,7 +273,7 @@ def getListsOfGroupedMemories(aProcModule):
 
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2n1"), then alphabetically
     zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p) else int("".join([i for i in p[:-2] if i.isdigit()]))) # sort by number
+    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number. need to use p[:-2] if we have nX
     zipped_list.sort(key=lambda (m, p): p) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
 
@@ -309,6 +309,23 @@ def arrangeMemoriesByKey(memory_list):
 #                    the wires file. Once these scripts also generate the top-level HLS
 #                    blocks, these functions might not be needed
 ########################################
+
+################################
+# VMRouter
+################################
+def writeTemplatePars_IR(aVMRModule):
+    #raise ValueError("VMRouter is not implemented yet!")
+    print("InputRouter template parameters are not implemented yet! But does it matter?!")
+    return ""
+
+def matchArgPortNames_IR(argname, portname, memoryname):
+    if 'hInputStubs' in argname:
+        return 'stubin' in portname
+    elif 'hOutputStubs' in argname:
+        return 'stubout' in portname
+    else:
+        print "matchArgPortNames_IR: Unknown argument", argname
+        return False
 
 ################################
 # VMRouter
@@ -836,7 +853,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                               f_matchArgPortNames, first_of_type, extraports):
     ####
     # function name
-    assert(module.mtype in ['VMRouter','TrackletEngine','TrackletCalculator',
+    assert(module.mtype in ['InputRouter', 'VMRouter','TrackletEngine','TrackletCalculator',
                             'ProjectionRouter','MatchEngine','MatchCalculator',
                             'DiskMatchCalculator','FitTrack','PurgeDuplicate'])
 
@@ -926,6 +943,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     argname_is_array = (tmp_argname.find('[') != -1) # Check if array
 
                     # Special case if argname is an array
+                    # Note: it assumes the arrays are partitioned
                     if argname_is_array:
                         # Assumes no more than two dimensions
                         argname_is_2d_array = (tmp_argname.find('][') != -1) # Check if two-dimensional array
@@ -993,8 +1011,13 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     return str_ctrl_wire,module_str
 
 ################################
-def writeModuleInstance(module, hls_src_dir, first_of_type, extraports):
-    if module.mtype == 'VMRouter':
+def writeModuleInstance(module, hls_src_dir, first_of_type):
+    if module.mtype == 'InputRouter':
+        return writeModuleInst_generic(module, hls_src_dir,
+                                         writeTemplatePars_IR,
+                                         matchArgPortNames_IR,
+                                         first_of_type)
+    elif module.mtype == 'VMRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMR,
                                          matchArgPortNames_VMR,

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -273,8 +273,8 @@ def getListsOfGroupedMemories(aProcModule):
 
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number
-    zipped_list.sort(key=lambda (m, p): p if ('PHI' not in p or not p[-1].isdigit()) else p[:p.index('PHI')]) # sort alphabetically
+    zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else int("".join([i for i in p if i.isdigit()]))) # sort by number
+    zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else p[:p.index('PHI')]) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
     memList, portList = list(memList), list(portList)
 

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -679,7 +679,7 @@ def checkIfTrueMatch(memory, argname):
     memory_instance = memory.inst
     phi_region = memory_instance.split("PHI")[1][0]
     position = memory_instance.split("_")[1][0:2]
-
+    print(memory_instance, phi_region, position)
     if 'memoriesME' in argname:
         return (memory_instance[3:5] == 'ME')
     elif 'memoriesTEI' in argname:
@@ -919,10 +919,11 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                 else:
                     # Use the provided matching rules
                     foundMatch = f_matchArgPortNames(argname, portname)
+                    print(argname, portname, foundMatch)
                     # Bodge to distinguish between ME and TE memories, and IL 2S/PS
-                    if 'vmstubout' in portname or 'stubin' in portname:
+                    if foundMatch and ('vmstubout' in portname or 'stubin' in portname):
                         foundMatch = checkIfTrueMatch(memory, argname)
-
+                    print(foundMatch)
                 if foundMatch:
                     # Create temporary argument name as argname can be an array and have several matches
                     tmp_argname = argname

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -274,7 +274,7 @@ def getListsOfGroupedMemories(aProcModule):
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = zip(memList, portList)
     zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number
-    zipped_list.sort(key=lambda (m, p): p) # sort alphabetically
+    zipped_list.sort(key=lambda (m, p): p if ('PHI' not in p or not p[-1].isdigit()) else p[:p.index('PHI')+1]) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
     memList, portList = list(memList), list(portList)
 
@@ -945,9 +945,9 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     argname_is_array = (tmp_argname.find('[') != -1) # Check if array
 
                     # Special case if argname is an array
-                    # Note: it assumes the arrays are partitioned
+                    # Note: it  the arrays are partitioned
                     if argname_is_array:
-                        # Assumes no more than two dimensions
+                        #  no more than two dimensions
                         argname_is_2d_array = (tmp_argname.find('][') != -1) # Check if two-dimensional array
                         tmp_argname = tmp_argname.split('[')[0] # Remove "[...]"
 

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -273,9 +273,10 @@ def getListsOfGroupedMemories(aProcModule):
 
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2n1"), then alphabetically
     zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number. need to use p[:-2] if we have nX
+    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p[:-2] if i.isdigit()]))) # sort by number. need to use p[:-2] if we have nX
     zipped_list.sort(key=lambda (m, p): p) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
+    memList, portList = list(memList), list(portList)
 
     return memList, portList
 

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -273,7 +273,7 @@ def getListsOfGroupedMemories(aProcModule):
 
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2n1"), then alphabetically
     zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number. need to use p[:-2] if we have nX
+    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number. Need to use p[:-2] if we have nX at the end
     zipped_list.sort(key=lambda (m, p): p) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
     memList, portList = list(memList), list(portList)
@@ -954,20 +954,20 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                                 tmp_argname += "_" + str(array_dict[tmp_argname])
                         # For two-dimensional arrays
                         else:
-                            tmp_portname = portname # portname without the "nX" at the end
                             # Keep track of the array names and the number of array elements
                             # array_dict[tmp_argname] keeps track of the first dimension
-                            # array_dict[tmp_portname] keeps track of the second dimension
+                            # array_dict[portname] keeps track of the second dimension
                             if tmp_argname not in array_dict:
                                 array_dict[tmp_argname] = 0
-                                array_dict[tmp_portname] = 0
-                            elif tmp_portname not in array_dict:
+                                array_dict[portname] = 0
+                            elif portname not in array_dict:
                                 array_dict[tmp_argname] += 1
-                                array_dict[tmp_portname] = 0
+                                array_dict[portname] = 0
                             else:
-                                array_dict[tmp_portname] += 1
+                                array_dict[portname] += 1
                             # Add array index to the name as HLS implements one port for each array element
-                            tmp_argname += "_" + str(array_dict[tmp_argname]) + "_" + str(array_dict[tmp_portname])
+                            tmp_argname += "_" + str(array_dict[tmp_argname]) + "_" + str(array_dict[portname])
+
                     # Add the memory instance to the port string
                     # Assumes a sorted memModuleList due to arrays
                     if portname.replace("inner","").find("in") != -1:

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -393,7 +393,7 @@ def matchArgPortNames_VMR(argname, portname, memoryname):
 def writeTemplatePars_TE(aTEModule):
     return ""
 
-def matchArgPortNames_TE(argname, portname):
+def matchArgPortNames_TE(argname, portname, memoryname):
     """
     # Define rules to match the argument and the port names for MatchEngine
     """
@@ -921,7 +921,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
         elif argtype == "BXType&" or argtype == "BXType &": # Could change this in the HLS instead
             if first_of_type:
                 string_bx_out += writeProcBXPort(module.mtype_short(),False,False) # output bx
-        elif "table" in argname:
+        elif "table" in argname: # For TE
             string_ports = writeLUTPorts(argname, module)
             string_parameters = writeLUTParameters(argname, module)
             module_str += writeLUTCombination(module, argname, string_ports, string_parameters)
@@ -1002,8 +1002,6 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
 
                     if not argname_is_array: break # We only need one match for non-arrays
     # end of loop
-<<<<<<< HEAD
-=======
 
     # External LUTs
     string_luts = ""
@@ -1012,7 +1010,6 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
         string_luts += writeInputLinkPhiBinsPort(numberOfMemoriesPerLayer(module))
 
     # Add all ports together
->>>>>>> fd1e3e2... debugged IR-VMR chain. needs debugging for mixedIO
     string_ports = ""
     string_ports += string_ctrl_ports
     string_ports += string_bx_in
@@ -1028,12 +1025,12 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     return str_ctrl_wire,module_str
 
 ################################
-def writeModuleInstance(module, hls_src_dir, first_of_type):
+def writeModuleInstance(module, hls_src_dir, first_of_type, extraports):
     if module.mtype == 'InputRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_IR,
                                          matchArgPortNames_IR,
-                                         first_of_type)
+                                         first_of_type, extraports)
     elif module.mtype == 'VMRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMR,

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -271,7 +271,7 @@ def getListsOfGroupedMemories(aProcModule):
     memList = list(aProcModule.upstreams + aProcModule.downstreams)
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
-    # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
+    # Sort the VMSME and VMSTE using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = zip(memList, portList)
     zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else int("".join([i for i in p if i.isdigit()]))) # sort by number
     zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else p[:p.index('PHI')]) # sort alphabetically
@@ -315,8 +315,7 @@ def arrangeMemoriesByKey(memory_list):
 # InputRouter
 ################################
 def writeTemplatePars_IR(anIRModule):
-    #raise ValueError("InputRouter is not implemented yet!")
-    print("InputRouter template parameters are not implemented yet!")
+    #InputRouter template parameters are not implemented. Add if necessary.
     return ""
 
 def matchArgPortNames_IR(argname, portname, memoryname):
@@ -346,8 +345,7 @@ def numberOfMemoriesPerLayer(module):
 # VMRouter
 ################################
 def writeTemplatePars_VMR(aVMRModule):
-    #raise ValueError("VMRouter is not implemented yet!")
-    print("VMRouter template parameters are not implemented yet!")
+    #VMRouter template parameters are not implemented. Add if necessary.
     return ""
 
 def matchArgPortNames_VMR(argname, portname, memoryname):
@@ -945,7 +943,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     argname_is_array = (tmp_argname.find('[') != -1) # Check if array
 
                     # Special case if argname is an array
-                    # Note: it  the arrays are partitioned
+                    # Note: it assumes the arrays are partitioned
                     if argname_is_array:
                         #  no more than two dimensions
                         argname_is_2d_array = (tmp_argname.find('][') != -1) # Check if two-dimensional array
@@ -959,7 +957,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                             else:
                                 array_dict[tmp_argname] = 0
                             # Add array index to the name as HLS implements one port for each array element
-                            # Temporary bodge to account for encoded index in fullmatch memories
+                            # Temporary bodge to account for encoded index in fullmatch and projection memories
                             if tmp_argname == 'fullmatch':
                                 tmp_argname += "_" + str(decodeSeedIndex_MC(memory.inst))
                             elif tmp_argname == 'projout_barrel_ps' or tmp_argname == 'projout_barrel_2s' or tmp_argname == 'projout_disk':

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -673,14 +673,15 @@ def decodeSeedIndex_MC(memoryname):
         print "decodeSeedIndex_MC: Unknown memory name", memoryname
         return False
 
-# Temporary bodge to distinguish between the correct ME and TE memories
+# Temporary bodge to distinguish between the correct ME and TE memories, and IL PS/2S
 # as the matchArgPortNames don't have enough information to do that
 def checkIfTrueMatch(memory, argname):
-    phi_region = memory.inst[11]
-    position = memory.inst[6:8]
+    memory_instance = memory.inst
+    phi_region = memory_instance.split("PHI")[1][0]
+    position = memory_instance.split("_")[1][0:2]
 
     if 'memoriesME' in argname:
-        return (memory.inst[3:5] == 'ME')
+        return (memory_instance[3:5] == 'ME')
     elif 'memoriesTEI' in argname:
         if position == 'L1' or position == 'L3' or position == 'D1':
             return (phi_region in ['A','B','C','D','E','F','G','H']) # L1L21, L3L4, or D1D2 seeding
@@ -696,7 +697,15 @@ def checkIfTrueMatch(memory, argname):
     elif 'memoriesOL' in argname:
         if position == 'L1' or position == 'L2':
             return (phi_region in ['Q','R','S','T','W','X','Y','Z']) # L1D1 or L2D1 overlap seeding
-
+    elif 'inputStub' in argname:
+        if 'D' in position:
+            return ('PS' in memory_instance)
+        else:
+            return ('IL' in memory_instance)
+    elif 'inputStubDisk2S' in argname:
+        return ('2S' in memory_instance)
+    else:
+        return False
 
 ################################
 # FitTrack
@@ -910,8 +919,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                 else:
                     # Use the provided matching rules
                     foundMatch = f_matchArgPortNames(argname, portname)
-                    # Bodge to distinguish between ME and TE memories
-                    if 'vmstubout' in portname:
+                    # Bodge to distinguish between ME and TE memories, and IL 2S/PS
+                    if 'vmstubout' in portname or 'stubin' in portname:
                         foundMatch = checkIfTrueMatch(memory, argname)
 
                 if foundMatch:

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -271,9 +271,9 @@ def getListsOfGroupedMemories(aProcModule):
     memList = list(aProcModule.upstreams + aProcModule.downstreams)
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
-    # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2n1"), then alphabetically
+    # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number. Need to use p[:-2] if we have nX at the end
+    zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number
     zipped_list.sort(key=lambda (m, p): p) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
     memList, portList = list(memList), list(portList)
@@ -314,9 +314,9 @@ def arrangeMemoriesByKey(memory_list):
 ################################
 # InputRouter
 ################################
-def writeTemplatePars_IR(aVMRModule):
-    #raise ValueError("VMRouter is not implemented yet!")
-    print("InputRouter template parameters are not implemented yet! But does it matter?!")
+def writeTemplatePars_IR(anIRModule):
+    #raise ValueError("InputRouter is not implemented yet!")
+    print("InputRouter template parameters are not implemented yet!")
     return ""
 
 def matchArgPortNames_IR(argname, portname, memoryname):
@@ -347,7 +347,7 @@ def numberOfMemoriesPerLayer(module):
 ################################
 def writeTemplatePars_VMR(aVMRModule):
     #raise ValueError("VMRouter is not implemented yet!")
-    print("VMRouter template parameters are not implemented yet! But does it matter?!")
+    print("VMRouter template parameters are not implemented yet!")
     return ""
 
 def matchArgPortNames_VMR(argname, portname, memoryname):

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1001,6 +1001,10 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     if not argname_is_array: break # We only need one match for non-arrays
     # end of loop
 
+    # Check that all the ports/memories have been matched
+    if (memModuleList or portNameList):
+        raise ValueError("There are unmatched memories: "+" ,".join([m.inst for m in memModuleList]))
+
     # External LUTs
     string_luts = ""
     if module.mtype == "InputRouter": # Might be temporary

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -274,7 +274,7 @@ def getListsOfGroupedMemories(aProcModule):
     # Sort the lists using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = zip(memList, portList)
     zipped_list.sort(key=lambda (m, p): 0 if ('PHI' not in p or not p[-1].isdigit()) else int("".join([i for i in p if i.isdigit()]))) # sort by number
-    zipped_list.sort(key=lambda (m, p): p if ('PHI' not in p or not p[-1].isdigit()) else p[:p.index('PHI')+1]) # sort alphabetically
+    zipped_list.sort(key=lambda (m, p): p if ('PHI' not in p or not p[-1].isdigit()) else p[:p.index('PHI')]) # sort alphabetically
     memList, portList = zip(*zipped_list) # unzip
     memList, portList = list(memList), list(portList)
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,5 +1,4 @@
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
-from collections import OrderedDict
 
 def writeTopPreamble(all=True):
     string_preamble = "--! Standard libraries\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -250,6 +250,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
     parameterlist += "        INIT_HEX        => true,\n"
     parameterlist += "        RAM_PERFORMANCE => \"HIGH_PERFORMANCE\",\n"
 
+    if "VMSME_D" in memList[0].inst: # VMSME memories have 16 bins in the disks
+        parameterlist += "        NUM_MEM_BINS    => 16,\n"
+        parameterlist += "        NUM_ENTRIES_PER_MEM_BINS => 8,\n"
+
     # Write ports
     portlist += "        clka      => clk,\n"
     portlist += "        wea       => "+mtypeB+"_mem_A_wea(var),\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -161,11 +161,8 @@ def writeMemoryUtil(memDict, memInfoDict):
         num_pages = 2**memInfo.bxbitwidth
 
         if "DL" in mtypeB: # DTCLinks
-            arrName = "t_arr_"+mtypeB+"_empty_neg"
-            ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n" 
-
-            arrName = "t_arr_"+mtypeB+"_read"
-            ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n" 
+            arrName = "t_arr_"+mtypeB+"_1b"
+            ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n"
 
             arrName = "t_arr_"+mtypeB+"_DATA"
             ss += "  type "+arrName+" is array("+enumName+") of std_logic_vector("+str(bitwidth-1)+" downto 0);\n" 
@@ -333,8 +330,8 @@ def writeDTCLinkLHSPorts_interface(mtypeB):
 
     string_input_mems = ""
     string_input_mems += "    "+mtypeB+"_link_AV_dout       : in t_arr_"+mtypeB+"_DATA;\n"
-    string_input_mems += "    "+mtypeB+"_link_empty_neg       : in t_arr_"+mtypeB+"_empty_neg;\n"
-    string_input_mems += "    "+mtypeB+"_link_read : out t_arr_"+mtypeB+"_read;\n"
+    string_input_mems += "    "+mtypeB+"_link_empty_neg     : in t_arr_"+mtypeB+"_1b;\n"
+    string_input_mems += "    "+mtypeB+"_link_read          : out t_arr_"+mtypeB+"_1b;\n"
 
     return string_input_mems
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,4 +1,5 @@
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
+from collections import OrderedDict
 
 def writeTopPreamble(all=True):
     string_preamble = "--! Standard libraries\n"
@@ -629,3 +630,38 @@ def writeProcDTCLinkRHSPorts(argname,mem):
     string_mem_ports += "      "+argname+"_V_read        => "
     string_mem_ports += mem.keyName()+"_link_read("+mem.var()+"),\n"
     return string_mem_ports
+
+def writeInputLinkWordPort(module_instance, memoriesPerLayer):
+    """
+    # Processing module port assignment: InputRouter kInputLink port
+    """
+    inputLinkWord = ""
+
+    # Loop over each layer/disk the module instance writes to. Repeat up to four times.
+    for layer in memoriesPerLayer:
+        isBarrelBit = "1" if "L" in layer else "0" # Is barrel bit
+        inputLinkWord = '{0:03b}'.format(int(layer[1])) + isBarrelBit + inputLinkWord # Add the layer number (3 bits) and the barrelbit
+
+    inputLinkWord = inputLinkWord.zfill(16) # Pad with zeros so it contains 16 bits
+    inputLinkWord = ("1" if "2S" in module_instance else "0") + inputLinkWord # Is 2S bit
+    inputLinkWord = '{0:03b}'.format(len(memoriesPerLayer)) + inputLinkWord # Number of layers
+
+    string_ilword_port = "      hLinkWord_V => \""+inputLinkWord+"\",\n"
+
+    return string_ilword_port
+
+def writeInputLinkPhiBinsPort(memoriesPerLayer):
+    """
+    # Processing module port assignment: InputRouter kNPhiBns/hPhBnWord port
+    """
+    phiBinWord = ""
+
+    # Loop through the layers and write the number of memories as three bits to phiBinWord
+    for layer in memoriesPerLayer:
+        phiBinWord = '{0:03b}'.format(memoriesPerLayer[layer]) + phiBinWord
+    
+    phiBinWord = phiBinWord.zfill(12) # Pad with zeros so it contains 12 bits
+
+    string_phibin_port = "      hPhBnWord_V => \""+phiBinWord+"\",\n"
+
+    return string_phibin_port

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -12,7 +12,7 @@ def writeTopPreamble(all=True):
 
 def writeModulesPreamble():
     string_preamble = "\n"
-    string_preamble = "begin\n\n"
+    string_preamble = "\nbegin\n\n"
     return string_preamble
 
 def writeTBPreamble():
@@ -161,10 +161,10 @@ def writeMemoryUtil(memDict, memInfoDict):
         num_pages = 2**memInfo.bxbitwidth
 
         if "DL" in mtypeB: # DTCLinks
-            arrName = "t_arr_"+mtypeB+"_SOMETHING_IN"
+            arrName = "t_arr_"+mtypeB+"_empty_neg"
             ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n" 
 
-            arrName = "t_arr_"+mtypeB+"_SOMETHING_OUT"
+            arrName = "t_arr_"+mtypeB+"_read"
             ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n" 
 
             arrName = "t_arr_"+mtypeB+"_DATA"
@@ -322,16 +322,15 @@ def writeMemoryLHSPorts_interface(mtypeB, extraports=False):
 
     return string_input_mems
 
-def writeDTCLinkPorts_interface(mtypeB):
+def writeDTCLinkLHSPorts_interface(mtypeB):
     """
-    # Top-level interface: DTC link' ports.
+    # Top-level interface: input DTC link ports.
     """
-    
+
     string_input_mems = ""
     string_input_mems += "    "+mtypeB+"_link_AV_dout       : in t_arr_"+mtypeB+"_DATA;\n"
-    string_input_mems += "    "+mtypeB+"_link_SOMETHING_IN       : in t_arr_"+mtypeB+"_SOMETHING_IN;\n"
-    string_input_mems += "    "+mtypeB+"_link_SOMETHING_OUT : out t_arr_"+mtypeB+"_SOMETHING_OUT;\n"
-    
+    string_input_mems += "    "+mtypeB+"_link_empty_neg       : in t_arr_"+mtypeB+"_empty_neg;\n"
+    string_input_mems += "    "+mtypeB+"_link_read : out t_arr_"+mtypeB+"_read;\n"
 
     return string_input_mems
 
@@ -616,13 +615,13 @@ def writeLUTMemPorts(argname, module):
 
 def writeProcDTCLinkRHSPorts(argname,mem):
     """
-    # Processing module port assignment: inputs from memories
+    # Processing module port assignment: inputs from DTCLink FIFOs
     """
     string_mem_ports = ""
     string_mem_ports += "      "+argname+"_V_dout       => "
     string_mem_ports += mem.keyName()+"_link_AV_dout("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_V_empty_n  => "
-    string_mem_ports += mem.keyName()+"_link_SOMETHING_IN("+mem.var()+"),\n"
+    string_mem_ports += mem.keyName()+"_link_empty_neg("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_V_read        => "
-    string_mem_ports += mem.keyName()+"_link_SOMETHING_OUT("+mem.var()+"),\n"
+    string_mem_ports += mem.keyName()+"_link_read("+mem.var()+"),\n"
     return string_mem_ports

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -11,7 +11,7 @@ from WriteHDLUtils import arrangeMemoriesByKey, \
 from WriteVHDLSyntax import writeTopModuleOpener, writeTBOpener, writeTopModuleCloser, writeTopModuleEntityCloser, writeTBModuleCloser, \
                             writeTopPreamble, writeModulesPreamble, writeTBPreamble, writeTBMemoryStimulusInstance, writeTBMemoryReadInstance, \
                             writeMemoryUtil, writeTopLevelMemoryType, writeControlSignals_interface, \
-                            writeMemoryLHSPorts_interface, writeDTCLinkPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
+                            writeMemoryLHSPorts_interface, writeDTCLinkLHSPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
                             writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts, writeProcDTCLinkRHSPorts
 import ROOT
 import os, subprocess
@@ -117,7 +117,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
         if memInfo.is_initial:
             # Input arguments
             if "DL" in mtypeB: # DTCLink
-                string_input_mems += writeDTCLinkPorts_interface(mtypeB)
+                string_input_mems += writeDTCLinkLHSPorts_interface(mtypeB)
             else:
                 string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
         elif memInfo.is_final:

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -11,8 +11,8 @@ from WriteHDLUtils import arrangeMemoriesByKey, \
 from WriteVHDLSyntax import writeTopModuleOpener, writeTBOpener, writeTopModuleCloser, writeTopModuleEntityCloser, writeTBModuleCloser, \
                             writeTopPreamble, writeModulesPreamble, writeTBPreamble, writeTBMemoryStimulusInstance, writeTBMemoryReadInstance, \
                             writeMemoryUtil, writeTopLevelMemoryType, writeControlSignals_interface, \
-                            writeMemoryLHSPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
-                            writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts
+                            writeMemoryLHSPorts_interface, writeDTCLinkPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
+                            writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts, writeProcDTCLinkRHSPorts
 import ROOT
 import os, subprocess
 
@@ -35,6 +35,8 @@ def writeMemoryModules(memDict, memInfoDict, extraports):
     string_mem = ""
     # Loop over memory type
     for mtypeB in memDict:
+        if "DL" in mtypeB: # DTCLink
+            continue
         memList = memDict[mtypeB]
         memInfo = memInfoDict[mtypeB]
         string_wires_inst, string_mem_inst = writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports)
@@ -114,7 +116,10 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
         memInfo = memInfoDict[mtypeB]
         if memInfo.is_initial:
             # Input arguments
-            string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
+            if "DL" in mtypeB: # DTCLink
+                string_input_mems += writeDTCLinkPorts_interface(mtypeB)
+            else:
+                string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
         elif memInfo.is_final:
             # Output arguments
             string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)


### PR DESCRIPTION
Added implementation for the IR and the VMR. The scripts can now handle two-dimensional arrays of memories, provided that they are partitioned. It can also handle mixed output memories, i.e. memories of a certain type where some get read further down the chain while others don't. Intermediate final memories remain in the top-level, albeit unconnected to the interface, thus will be deleted by Vivado. When running with the -x flag, all intermediate memories gets ports on the interface (worth noting that the resource usage will differ compared to the default script as no memories will be deleted by vivado in this case). The inputs ports (DTCLinks) to the IRs are connected directly to the interface.

The simplest chain "-uut VMR_L2PHIA -u 1 -d 0", which contains two IRs and one VMR has been successfully synthesised and implemented in Vivado. No test bench has been created yet.

NOTE: the scripts use the wires.dat, processingmodules.dat, and memorymodules.dat from https://github.com/cms-L1TK/firmware-hls/pull/151 (downloaded by download.sh, then found in /LUTs); and the IR from https://github.com/cms-L1TK/firmware-hls/tree/IR_moveLUTs, thus should not be merged until those HLS firmware branches has been merged. 

NOTE 2: To implement and synthesise the IR-VMR chain that was created by the scripts, some minor edits has to be done to the firmware HLS. A PR for those changes will be made.