### PR TITLE
Functions for getting a string version of the enums

### DIFF
--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -115,6 +115,7 @@ def writeMemoryUtil(memDict, memInfoDict):
     """
     ss = writeTopPreamble(False)
     ss += "package memUtil_pkg is\n\n"
+    ss += "  -- ########################### Types ###########################\n\n"
 
     for mtypeB in memDict:
         memInfo = memInfoDict[mtypeB]
@@ -183,7 +184,29 @@ def writeMemoryUtil(memDict, memInfoDict):
             arrName = "t_arr_"+mtypeB+"_NENT"
             ss += "  type "+arrName+" is array("+enumName+") of t_arr"+str(num_pages)+varStr+";\n"
 
-    ss += "end package memUtil_pkg;\n"
+    ss += "\n  -- ########################### Functions ###########################\n\n"
+    ss += "  -- Following functions are needed because VHDL is not case sensitive when converting an enum to a string\n"
+
+    for mtypeB in memDict:
+        ss += "  function memory_enum_to_string(val: enum_"+mtypeB+") return string;\n";
+
+    ss += "\nend package memUtil_pkg;\n\n"
+    ss += "package body memUtil_pkg is\n\n"
+    ss += "  -- ########################### Functions ###########################\n\n"
+ 
+    for mtypeB in memDict:
+        memList = memDict[mtypeB]
+        
+        ss += "  function memory_enum_to_string(val: enum_"+mtypeB+") return string is\n";
+        ss += "  begin\n"
+        ss += "    case val is\n"
+        for mem in memList:
+            ss += "       when "+mem.var()+" => return \""+mem.var()+"\";\n"
+        ss += "    end case;\n"
+        ss += "    return \"No conversion found.\";\n"
+        ss += "  end memory_enum_to_string;\n\n"
+
+    ss += "end package body memUtil_pkg;\n"
 
     return ss;
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -185,7 +185,7 @@ def writeMemoryUtil(memDict, memInfoDict):
             ss += "  type "+arrName+" is array("+enumName+") of t_arr"+str(num_pages)+varStr+";\n"
 
     ss += "\n  -- ########################### Functions ###########################\n\n"
-    ss += "  -- Following functions are needed because VHDL is not case sensitive when converting an enum to a string\n"
+    ss += "  -- Following functions are needed because VHDL doesn't preserve case when converting an enum to a string using image\n"
 
     for mtypeB in memDict:
         ss += "  function memory_enum_to_string(val: enum_"+mtypeB+") return string;\n";


### PR DESCRIPTION
Making the script write functions in memUtil_pkg.vhd that converts the memory enums to strings. These functions are needed as the current PRMEMC VHDL testbench assumes that all file names for each memory type are of the same length, which is not generally true for other chains. We avoid that issue with these functions (converting the enums directly isn't case sensitive, so that didn't work), and it also makes the VHDL testbenches shorter as one doesn't have to specify every single filename by hand.

Example of the PRMEMC memUtil_pkg.vhd: https://github.com/meisonlikesicecream/firmware-hls/blob/update_VHDL_tb/IntegrationTests/PRMEMC/hdl/memUtil_pkg.vhd

Example of what the PRMEMC testbench could look like: https://github.com/meisonlikesicecream/firmware-hls/blob/update_VHDL_tb/IntegrationTests/PRMEMC/tb/tb_tf_top.vhd

I'll make a PR with the above examples to the firmware repo as well if this PR gets approved.