### PR TITLE
TrackBuilder support

### DIFF
--- a/Graph.py
+++ b/Graph.py
@@ -110,7 +110,7 @@ for line in fi :
         processingmodules.append([6,splitline[1]])
     if (splitline[0]=="MatchEngine:") :
         processingmodules.append([7,splitline[1]])
-    if (splitline[0]=="MatchCalculator:" or splitline[0]=="DiskMatchCalculator:") :
+    if (splitline[0]=="MatchCalculator:") :
         processingmodules.append([8,splitline[1]])
     if (splitline[0]=="MatchTransceiver:") :
         processingmodules.append([9,splitline[1]])

--- a/GraphAnalyzer.py
+++ b/GraphAnalyzer.py
@@ -89,7 +89,7 @@ for aProcMod in proc_list:
     elif moduletype == 'MatchEngine':
         h_proc_input_num_me.Fill(ninputs)
         h_proc_output_num_me.Fill(noutputs)
-    elif moduletype in ['MatchCalculator','DiskMatchCalculator']:
+    elif moduletype == 'MatchCalculator':
         h_proc_input_num_mc.Fill(ninputs)
         h_proc_output_num_mc.Fill(noutputs)
     elif moduletype == 'FitTrack':

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -11,7 +11,6 @@ import copy
 #    'ProjectionRouter':4,
 #    'MatchEngine':5,
 #    'MatchCalculator':6,
-#    'DiskMatchCalculator':6,
 #    'FitTrack':7,
 #    'PurgeDuplicate':8
 #}
@@ -44,7 +43,6 @@ ModuleDrawWidth_dict = {'DTCLink':2.0,
                         'ProjectionRouter':2.5,
                         'MatchEngine':3.0,
                         'MatchCalculator':2.5,
-                        'DiskMatchCalculator':2.5,
                         'FitTrack':2.0,
                         'TrackBuilder':2.0,
                         'PurgeDuplicate':2.0,
@@ -295,9 +293,6 @@ class TrackletGraph(object):
         for i,line_proc in enumerate(file_proc):
             # Processing module type
             proc_type = line_proc.split(':')[0].strip()
-            # temporary hack: DiskMatchCalculator-->MatchCalculator
-            if proc_type == "DiskMatchCalculator":
-                proc_type = "MatchCalculator"
             # temporary hack: FitTrack-->TrackBuilder
             if proc_type == "FitTrack":
                 proc_type = "TrackBuilder"

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -229,7 +229,7 @@ class TrackletGraph(object):
             mem.bxbitwidth = 3
         elif (    mem.mtype == "TrackWord"
                or mem.mtype == "BarrelStubWord" or mem.mtype == "DiskStubWord"):
-            mem.bxbitwidth = 0
+            mem.bxbitwidth = 0 # FIFO memories
         else:
             raise ValueError("Bxbitwidth undefined for "+mem.mtype)
 

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -246,7 +246,7 @@ class TrackletGraph(object):
             mem.has_numEntries_out = False
         elif mem.mtype == "AllProj" and not mem.is_final:
             mem.has_numEntries_out = False
-        elif mem.mtype == "TrackletParameters":
+        elif mem.mtype == "TrackletParameters" and not mem.is_final:
             mem.has_numEntries_out = False
         else:
             mem.has_numEntries_out = True

--- a/Wires.py
+++ b/Wires.py
@@ -405,10 +405,8 @@ for proc in processingmodules :
     if "ME_" in proc:
         if "VMRME_" not in proc:
             fp2.write("MatchEngine: "+proc+"\n")
-    if "MC_L" in proc:
+    if "MC_" in proc:
         fp2.write("MatchCalculator: "+proc+"\n")
-    if "MC_D" in proc:
-        fp2.write("DiskMatchCalculator: "+proc+"\n")
     if "MP_" in proc:
         fp2.write("MatchProcessor: "+proc+"\n")
         MP_nmod+=1

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -744,10 +744,16 @@ def writeTemplatePars_TB(aTBModule):
     return ""
 
 def matchArgPortNames_TB(argname, portname, memoryname):
+    fm_layer_or_disk = None
+    if memoryname.startswith("FM_"):
+        fm_layer_or_disk = memoryname.split("_")[2][0]
+
     if argname.startswith("trackletParameters"):
         return portname.startswith("tpar")
     if argname.startswith("barrelFullMatches"):
-        return portname.startswith("fullmatch")
+        return (fm_layer_or_disk == "L" and portname.startswith("fullmatch"))
+    if argname.startswith("diskFullMatches"):
+        return (fm_layer_or_disk == "D" and portname.startswith("fullmatch"))
     if argname.startswith("trackWord"):
         return portname.startswith("trackword")
     if argname.startswith("barrelStubWords"):

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -6,7 +6,7 @@
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
 
-from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts
+from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeProcTrackStreamLHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts
 import re
 # This dictionary preserves key order. 
 # (Requires python >= 2.7. And can be replace with normal dict for >= 3.7)
@@ -737,6 +737,27 @@ def matchArgPortNames_FT(argname, portname, memoryname):
     return False
 
 ################################
+# TrackBuilder
+################################
+
+def writeTemplatePars_TB(aTBModule):
+    return ""
+
+def matchArgPortNames_TB(argname, portname, memoryname):
+    if argname.startswith("trackletParameters"):
+        return portname.startswith("tpar")
+    if argname.startswith("barrelFullMatches"):
+        return portname.startswith("fullmatch")
+    if argname.startswith("trackWord"):
+        return portname.startswith("trackword")
+    if argname.startswith("barrelStubWords"):
+        return portname.startswith("barrelstub")
+    if argname.startswith("diskStubWords"):
+        return portname.startswith("diskstub")
+    print "matchArgPortNames_TB: Unknown argument name", argname
+    return False
+
+################################
 # PurgeDuplicate
 ################################
 
@@ -823,13 +844,19 @@ def parseProcFunction(proc_name, fname_def):
         args = args.replace("const","").strip()
         # get rid of '*'
         args = args.replace("*","").strip()
-        # get rid of '&' ?
 
         # get rid of '[...]' in case it is an array
         #args = args.split('[')[0]
 
         # argument type
         atype = ' '.join(args.split()[:-1]) # combine all strings except the last
+
+        # get rid of '&' and append it to the type
+        if "&" in args:
+            args = args.replace("&","").strip()
+            if "&" not in atype:
+                atype += "&"
+
         arg_types_list.append(atype)
         # argument name
         aname = args.split()[-1] # the last entry in the list
@@ -855,7 +882,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     # function name
     assert(module.mtype in ['InputRouter', 'VMRouter','TrackletEngine','TrackletCalculator',
                             'ProjectionRouter','MatchEngine','MatchCalculator',
-                            'DiskMatchCalculator','FitTrack','PurgeDuplicate'])
+                            'DiskMatchCalculator','FitTrack','TrackBuilder','PurgeDuplicate'])
 
     # Add internal BX wire and start registers
     str_ctrl_wire = ""
@@ -942,11 +969,23 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     tmp_argname = argname
                     argname_is_array = (tmp_argname.find('[') != -1) # Check if array
 
+                    # TrackWords are treated differently because they are
+                    # currently streams
+                    if "TW" in memory.inst:
+                        argname_is_array = False
+                        tmp_argname = tmp_argname.split('[')[0] # Remove "[...]"
+
                     # Special case if argname is an array
                     # Note: it assumes the arrays are partitioned
                     if argname_is_array:
                         #  no more than two dimensions
                         argname_is_2d_array = (tmp_argname.find('][') != -1) # Check if two-dimensional array
+
+                        # BarrelWords and DiskWords are treated differently
+                        # because they are currently streams
+                        if "BW" in memory.inst or "DW" in memory.inst:
+                            argname_is_2d_array = False
+
                         tmp_argname = tmp_argname.split('[')[0] # Remove "[...]"
 
                         # For one-dimensional arrays
@@ -987,8 +1026,18 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                             string_mem_ports += writeProcDTCLinkRHSPorts(tmp_argname,memory)
                         else:
                             string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)
+
+                            # Two sets of input FullMatch ports are generated
+                            # because the TrackBuilder performs two reads per
+                            # iteration
+                            if "FM" in memory.inst:
+                                string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory,1)
+
                     if portname.replace("outer","").find("out") != -1:
-                        string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
+                        if "TW" in memory.inst or "BW" in memory.inst or "DW" in memory.inst:
+                            string_mem_ports += writeProcTrackStreamLHSPorts(tmp_argname,memory)
+                        else:
+                            string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
                     if portname.find("trackpar") != -1 and module.mtype == "TrackletCalculator":
                         string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
                     elif portname.find("trackpar") != -1 and module.mtype == "PurgeDuplicates":
@@ -1067,6 +1116,11 @@ def writeModuleInstance(module, hls_src_dir, first_of_type, extraports):
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_FT,
                                          matchArgPortNames_FT,
+                                         first_of_type, extraports)
+    elif module.mtype == 'TrackBuilder':
+        return writeModuleInst_generic(module, hls_src_dir,
+                                         writeTemplatePars_TB,
+                                         matchArgPortNames_TB,
                                          first_of_type, extraports)
     elif module.mtype == 'PurgeDuplicate':
         return writeModuleInst_generic(module, hls_src_dir,

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -882,7 +882,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     # function name
     assert(module.mtype in ['InputRouter', 'VMRouter','TrackletEngine','TrackletCalculator',
                             'ProjectionRouter','MatchEngine','MatchCalculator',
-                            'DiskMatchCalculator','FitTrack','TrackBuilder','PurgeDuplicate'])
+                            'FitTrack','TrackBuilder','PurgeDuplicate'])
 
     # Add internal BX wire and start registers
     str_ctrl_wire = ""
@@ -1107,7 +1107,7 @@ def writeModuleInstance(module, hls_src_dir, first_of_type, extraports):
                                          writeTemplatePars_ME,
                                          matchArgPortNames_ME,
                                          first_of_type, extraports)
-    elif module.mtype in ['MatchCalculator','DiskMatchCalculator']:
+    elif module.mtype == 'MatchCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_MC,
                                          matchArgPortNames_MC,

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -814,7 +814,7 @@ def writeProcFunction_generic(module, hls_src_dir, f_writeTemplatePars,
     # function name
     assert(module.mtype in ['VMRouter','TrackletEngine','TrackletCalculator',
                             'ProjectionRouter','MatchEngine','MatchCalculator',
-                            'DiskMatchCalculator','FitTrack','PurgeDuplicate'])
+                            'FitTrack','PurgeDuplicate'])
     function_str = module.mtype
     # Update here if the function name is not exactly the same as the module type
 
@@ -830,7 +830,6 @@ def writeProcFunction_generic(module, hls_src_dir, f_writeTemplatePars,
     # Special cases (probably should make the naming consistent...)
     if module.mtype in ['TrackletEngine','MatchEngine']:
         fname_def = module.mtype + '.h'
-    # DiskMatchCalculator?
     
     fname_def = hls_src_dir.rstrip('/')+'/'+fname_def
     
@@ -875,7 +874,7 @@ def writeProcFunction(module, hls_src_dir):
         return writeProcFunction_generic(module, hls_src_dir,
                                          writeTemplatePars_ME,
                                          matchArgPortNames_ME)
-    elif module.mtype in ['MatchCalculator','DiskMatchCalculator']:
+    elif module.mtype == 'MatchCalculator':
         return writeProcFunction_generic(module, hls_src_dir,
                                          writeTemplatePars_MC,
                                          matchArgPortNames_MC)

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -161,7 +161,10 @@ def writeMemoryUtil(memDict, memInfoDict):
         bitwidth = int(mtypeB.split("_")[1]);
         num_pages = 2**memInfo.bxbitwidth
 
-        if "DL" in mtypeB: # DTCLinks
+        # address and nentries types not needed for DTC links or output track
+        # streams
+        if "DL" in mtypeB \
+           or "TW" in mtypeB or "BW" in mtypeB or "DW" in mtypeB:
             arrName = "t_arr_"+mtypeB+"_1b"
             ss += "  type "+arrName+" is array("+enumName+") of std_logic;\n"
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -385,6 +385,19 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo):
 
     return string_output_mems
 
+def writeTrackStreamRHSPorts_interface(mtypeB):
+    """
+    # Top-level interface: output track stream ports.
+    # Inputs:
+    #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
+    """
+    string_output_mems = ""
+    string_output_mems += "    "+mtypeB+"_stream_AV_din     : in t_arr_"+mtypeB+"_DATA;\n"
+    string_output_mems += "    "+mtypeB+"_stream_full_neg   : in t_arr_"+mtypeB+"_1b;\n"
+    string_output_mems += "    "+mtypeB+"_stream_write      : out t_arr_"+mtypeB+"_1b;\n"
+
+    return string_output_mems
+
 def writeTBControlSignals(topfunc, first_proc, last_proc):
     """
     # Verilog test bench: control signals
@@ -558,19 +571,19 @@ def writeProcMemoryLHSPorts(argname,mem):
 
     return string_mem_ports
 
-def writeProcMemoryRHSPorts(argname,mem):
+def writeProcMemoryRHSPorts(argname,mem,portindex=0):
     """
     # Processing module port assignment: inputs from memories
     """
     string_mem_ports = ""
-    string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => "
+    string_mem_ports += "      "+argname+"_dataarray_data_V_ce"+str(portindex)+"       => "
     string_mem_ports += mem.keyName()+"_mem_A_enb("+mem.var()+"),\n"
-    string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => "
+    string_mem_ports += "      "+argname+"_dataarray_data_V_address"+str(portindex)+"  => "
     string_mem_ports += mem.keyName()+"_mem_AV_readaddr("+mem.var()+"),\n"
-    string_mem_ports += "      "+argname+"_dataarray_data_V_q0        => "
+    string_mem_ports += "      "+argname+"_dataarray_data_V_q"+str(portindex)+"        => "
     string_mem_ports += mem.keyName()+"_mem_AV_dout("+mem.var()+"),\n"
 
-    if mem.has_numEntries_out:
+    if mem.has_numEntries_out and portindex == 0:
         for i in range(0,2**mem.bxbitwidth):
             if mem.is_binned:
                 for j in range(0,8):
@@ -642,12 +655,25 @@ def writeProcDTCLinkRHSPorts(argname,mem):
     # Processing module port assignment: inputs from DTCLink FIFOs
     """
     string_mem_ports = ""
-    string_mem_ports += "      "+argname+"_V_dout       => "
+    string_mem_ports += "      "+argname+"_V_dout     => "
     string_mem_ports += mem.keyName()+"_link_AV_dout("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_V_empty_n  => "
     string_mem_ports += mem.keyName()+"_link_empty_neg("+mem.var()+"),\n"
-    string_mem_ports += "      "+argname+"_V_read        => "
+    string_mem_ports += "      "+argname+"_V_read     => "
     string_mem_ports += mem.keyName()+"_link_read("+mem.var()+"),\n"
+    return string_mem_ports
+
+def writeProcTrackStreamLHSPorts(argname,mem):
+    """
+    # Processing module port assignment: output track streams
+    """
+    string_mem_ports = ""
+    string_mem_ports += "      "+argname+"_V_din       => "
+    string_mem_ports += mem.keyName()+"_stream_AV_din("+mem.var()+"),\n"
+    string_mem_ports += "      "+argname+"_V_full_n    => "
+    string_mem_ports += mem.keyName()+"_stream_full_neg("+mem.var()+"),\n"
+    string_mem_ports += "      "+argname+"_V_write     => "
+    string_mem_ports += mem.keyName()+"_stream_write("+mem.var()+"),\n"
     return string_mem_ports
 
 def writeInputLinkWordPort(module_instance, memoriesPerLayer):

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -395,9 +395,9 @@ def writeTrackStreamRHSPorts_interface(mtypeB):
     #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
     """
     string_output_mems = ""
-    string_output_mems += "    "+mtypeB+"_stream_AV_din     : in t_arr_"+mtypeB+"_DATA;\n"
-    string_output_mems += "    "+mtypeB+"_stream_full_neg   : in t_arr_"+mtypeB+"_1b;\n"
-    string_output_mems += "    "+mtypeB+"_stream_write      : out t_arr_"+mtypeB+"_1b;\n"
+    string_output_mems += "    "+mtypeB+"_stream_AV_din       : in t_arr_"+mtypeB+"_DATA;\n"
+    string_output_mems += "    "+mtypeB+"_stream_A_full_neg   : in t_arr_"+mtypeB+"_1b;\n"
+    string_output_mems += "    "+mtypeB+"_stream_A_write      : out t_arr_"+mtypeB+"_1b;\n"
 
     return string_output_mems
 
@@ -674,9 +674,9 @@ def writeProcTrackStreamLHSPorts(argname,mem):
     string_mem_ports += "      "+argname+"_V_din       => "
     string_mem_ports += mem.keyName()+"_stream_AV_din("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_V_full_n    => "
-    string_mem_ports += mem.keyName()+"_stream_full_neg("+mem.var()+"),\n"
+    string_mem_ports += mem.keyName()+"_stream_A_full_neg("+mem.var()+"),\n"
     string_mem_ports += "      "+argname+"_V_write     => "
-    string_mem_ports += mem.keyName()+"_stream_write("+mem.var()+"),\n"
+    string_mem_ports += mem.keyName()+"_stream_A_write("+mem.var()+"),\n"
     return string_mem_ports
 
 def writeInputLinkWordPort(module_instance, memoriesPerLayer):

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -395,7 +395,7 @@ def writeTrackStreamRHSPorts_interface(mtypeB):
     #   mTypeB  = memory type & its bits width (TPROJ_58b etc.)
     """
     string_output_mems = ""
-    string_output_mems += "    "+mtypeB+"_stream_AV_din       : in t_arr_"+mtypeB+"_DATA;\n"
+    string_output_mems += "    "+mtypeB+"_stream_AV_din       : out t_arr_"+mtypeB+"_DATA;\n"
     string_output_mems += "    "+mtypeB+"_stream_A_full_neg   : in t_arr_"+mtypeB+"_1b;\n"
     string_output_mems += "    "+mtypeB+"_stream_A_write      : out t_arr_"+mtypeB+"_1b;\n"
 

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -12,7 +12,7 @@ from WriteVHDLSyntax import writeTopModuleOpener, writeTBOpener, writeTopModuleC
                             writeTopPreamble, writeModulesPreamble, writeTBPreamble, writeTBMemoryStimulusInstance, writeTBMemoryReadInstance, \
                             writeMemoryUtil, writeTopLevelMemoryType, writeControlSignals_interface, \
                             writeMemoryLHSPorts_interface, writeDTCLinkLHSPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
-                            writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts, writeProcDTCLinkRHSPorts
+                            writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts, writeTrackStreamRHSPorts_interface
 import ROOT
 import os, subprocess
 
@@ -35,7 +35,9 @@ def writeMemoryModules(memDict, memInfoDict, extraports):
     string_mem = ""
     # Loop over memory type
     for mtypeB in memDict:
-        if "DL" in mtypeB: # DTCLink
+        # no memories for DTC links or output track streams
+        if "DL" in mtypeB \
+           or "TW" in mtypeB or "BW" in mtypeB or "DW" in mtypeB:
             continue
         memList = memDict[mtypeB]
         memInfo = memInfoDict[mtypeB]
@@ -122,7 +124,10 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
                 string_input_mems += writeMemoryLHSPorts_interface(mtypeB)
         elif memInfo.is_final:
             # Output arguments
-            string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)
+            if "TW" in mtypeB or "BW" in mtypeB or "DW" in mtypeB:
+                string_output_mems += writeTrackStreamRHSPorts_interface(mtypeB)
+            else:
+                string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(mtypeB, extraports)            

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -359,7 +359,7 @@ if __name__ == "__main__":
                         help="Detector region. A: all, L: barrel, D: disk")
     
     parser.add_argument('--uut', type=str, default=None, help="Unit Under Test")
-    parser.add_argument('--mut', type=str, choices=["IR","VMR", "TE", "TC", "PR", "ME", "MC"], default=None, help="Module Under Test")
+    parser.add_argument('--mut', type=str, choices=["IR","VMR", "TE", "TC", "PR", "ME", "MC", "FT"], default=None, help="Module Under Test")
     parser.add_argument('-u', '--nupstream', type=int, default=0,
                         help="Number of upstream processing steps to include")
     parser.add_argument('-d', '--ndownstream', type=int, default=0,
@@ -416,12 +416,16 @@ if __name__ == "__main__":
         for mem in memory_list:
             if mem.is_initial:
                 for proc in mem.upstreams:
+                    if proc is None:
+                        continue
                     for p in process_list:
                         if proc.inst == p.inst:
                             mem.is_initial = False
                             break
             if mem.is_final:
                 for proc in mem.downstreams:
+                    if proc is None:
+                        continue
                     for p in process_list:
                         if proc.inst == p.inst:
                             mem.is_final = False


### PR DESCRIPTION
This PR introduces support for the TrackBuilder.

In the current wiring, the TrackBuilder writes to a single TrackFit memory, while the actual HLS module streams its output as a track word and several stub words. To deal with this, after parsing the wires file, all TrackFit memories are replaced with the appropriate streams by the `split_track_fit_streams` function in TrackletGraph.py.

The top module for the reduced config pattern recognition can now be generated and seems plausible, though the modules involved will need to be modified before it can be synthesized:
~https://github.com/aehart/firmware-hls/blob/bf5ad0a74da90847e2083a26d918b95843be2cc8/IntegrationTests/ReducedConfigPR/hdl/SectorProcessor.vhd~
~https://github.com/aehart/firmware-hls/blob/0c31cdf5f0b518d55107688ec437b6797ef6d72b/IntegrationTests/ReducedConfigPR/hdl/SectorProcessor.vhd~
https://github.com/aehart/firmware-hls/blob/f6de97c5781a955ea8db551223bd9a72c4924748/IntegrationTests/ReducedConfigPR/hdl/SectorProcessor.vhd
Also, this top module can only be generated after manually removing the PD processing module from the wiring, although this is very easy to do.

Edit: The above top module was generated with the following recipe:
```bash
git clone -b track_builder https://github.com/aehart/project_generation_scripts.git
git clone https://github.com/cms-L1TK/firmware-hls.git

cd firmware-hls/emData/
./download.sh -t
cd ../../project_generation_scripts/
cp ../firmware-hls/emData/LUTs/*.dat ./

./makeReducedConfig.py -n True
sed -i "s/ PD\.trackin//g" reduced_wires.dat # remove output of TF_L1L2
sed -i '$d' reduced_wires.dat                # remove CT_L1L2 wires
sed -i '$d' reduced_processingmodules.dat    # remove PurgeDuplicates
sed -i '$d' reduced_memorymodules.dat        # remove CleanTrack

# SectorProcessor.vhd
./generator_hdl.py -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat
# SectorProcessorFull.vhd
./generator_hdl.py -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat -x
```