### PR TITLE
option to disable root (reduce dependencies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ generator_hdl.py --mut IR -u 0 -d 7 -w reduced_wires.dat -p reduced_processingmo
       -w, --wireconfig    Name of the wiring configuration .dat file
       --memprint_dir      Directory to search for memory printouts produced by the emulation
       --emData_dir        Directory into which the memory printout files are copied for the HLS project
+      --graph/--no-graph  Enable/disable making of the diagram. If disabled (not default) ROOT is not required.
       
  For generating a partial project:
  
@@ -98,6 +99,7 @@ By default the script will run starting with *TC_L1L2F*, and produced files call
     -o, --output        Prefix to add to all output files
     -l, --layers        Select the layer pair to create seeds with. By default this is "L1L2". 
     -n, --noneg         Remove all negative eta modules from the config. Done by default.
+    --graph/--no-graph  Enable/disable making of the diagram. If disabled (not default) ROOT is not required.
 
 -----------------------------------------------------------------
 

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -13,7 +13,6 @@ from WriteVHDLSyntax import writeTopModuleOpener, writeTBOpener, writeTopModuleC
                             writeMemoryUtil, writeTopLevelMemoryType, writeControlSignals_interface, \
                             writeMemoryLHSPorts_interface, writeDTCLinkLHSPorts_interface, writeMemoryRHSPorts_interface, writeTBControlSignals, \
                             writeFWBlockControlSignalPorts, writeFWBlockMemoryLHSPorts, writeFWBlockMemoryRHSPorts, writeTrackStreamRHSPorts_interface
-import ROOT
 import os, subprocess
 
 ########################################
@@ -372,7 +371,11 @@ if __name__ == "__main__":
     parser.add_argument('--memprint_dir', type=str,
                         default="../fpga_emulation_longVM/MemPrints/",
                         help="Directory of emulation memory printouts")
-    
+    parser.add_argument('--graph', dest='graph', action='store_true',
+                        help="Make graph. Requires ROOT")
+    parser.add_argument('--no-graph', dest='graph', action='store_false',
+                        help="Do not make graph. Disable ROOT")
+    parser.set_defaults(graph=False)
     args = parser.parse_args()
 
     if args.extraports:
@@ -467,10 +470,12 @@ if __name__ == "__main__":
     ########################################
     #  Plot graph
     ########################################
-    pageWidth, pageHeight, dyBox, textSize = tracklet.draw_graph(process_list)
-    ROOT.gROOT.SetBatch(True)
-    ROOT.gROOT.LoadMacro('DrawTrackletProject.C')
-    ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize);
+    if ( args.graph == True ) :
+        import ROOT
+        pageWidth, pageHeight, dyBox, textSize = tracklet.draw_graph(process_list)
+        ROOT.gROOT.SetBatch(True)
+        ROOT.gROOT.LoadMacro('DrawTrackletProject.C')
+        ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize);
 
 
     ###############

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -375,7 +375,7 @@ if __name__ == "__main__":
                         help="Make graph. Requires ROOT")
     parser.add_argument('--no-graph', dest='graph', action='store_false',
                         help="Do not make graph. Disable ROOT")
-    parser.set_defaults(graph=False)
+    parser.set_defaults(graph=True)
     args = parser.parse_args()
 
     if args.extraports:

--- a/makeReducedConfig.py
+++ b/makeReducedConfig.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from TrackletGraph import TrackletGraph
-import ROOT
 import argparse
 from collections import OrderedDict
 
@@ -291,6 +290,9 @@ parser.add_argument("-s", "--sector", type=str, default="F", help="TC phi sector
 parser.add_argument("-o", "--output", type=str, default="reduced_", help="Prefix to add to all output files")
 parser.add_argument("-l", "--layers", type=str, default="L1L2", help="Select the layer pair to create seeds with")
 parser.add_argument("-n", "--noneg", type=bool, default=True, help="Remove all negative eta modules from the config")
+parser.add_argument('--graph', dest='graph', action='store_true', help="Make graph. Requires ROOT")
+parser.add_argument('--no-graph', dest='graph', action='store_false', help="Do not make graph. Disable ROOT")
+parser.set_defaults(graph=True)
 args = parser.parse_args()
 
 # Load in full project
@@ -311,7 +313,9 @@ reduced_wires.saveMemories("%smemorymodules.dat"%args.output)
 
 # Create a pdf of the .dat files we've made
 tracklet = TrackletGraph.from_configs("%sprocessingmodules.dat"%args.output,"%smemorymodules.dat"%args.output,"%swires.dat"%args.output)
-pageWidth, pageHeight, dyBox, textSize = tracklet.draw_graph(tracklet.get_all_proc_modules())
-ROOT.gROOT.SetBatch(True)
-ROOT.gROOT.LoadMacro('DrawTrackletProject.C')
-ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize)
+if ( args.graph) :
+    pageWidth, pageHeight, dyBox, textSize = tracklet.draw_graph(tracklet.get_all_proc_modules())
+    import ROOT
+    ROOT.gROOT.SetBatch(True)
+    ROOT.gROOT.LoadMacro('DrawTrackletProject.C')
+    ROOT.DrawTrackletProject(pageWidth, pageHeight, dyBox, textSize)


### PR DESCRIPTION
This will make moving to python3 easier and reduce dependencies for this tool. 

Only touches `generator_hdl.py` right now. 