### PR TITLE
Add support for Python3

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master python3 ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint 
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with pylint
+      run: |
+        # only python3 errors 
+        pylint --py3k *.py
+        # all other errors
+        # pylint *.py
+

--- a/Graph.py
+++ b/Graph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-
+from __future__ import print_function
+from __future__ import absolute_import
 import math
 
 fi = open("memorymodules.dat","r")

--- a/Graph.py
+++ b/Graph.py
@@ -9,7 +9,7 @@ memorycounts=[0,0,0,0,0,0,0,0,0,0,0]
 
 for line in fi :
     splitline=line.split(" ")
-    print "Line:",splitline
+    print("Line:",splitline)
     lenold=len(memorymodules)
     if (splitline[0]=="InputLink:") :
         memorymodules.append([1,splitline[1]])
@@ -79,9 +79,9 @@ for line in fi :
         memorycounts[memorymodules[len(memorymodules)-1][0]-1]+=1
 
 for x in memorymodules :
-    print x
+    print(x)
 
-print memorycounts
+print(memorycounts)
 
 
 
@@ -92,7 +92,7 @@ processingcounts=[0,0,0,0,0,0,0,0,0,0]
 
 for line in fi :
     splitline=line.split(" ")
-    print "Line:",splitline
+    print("Line:",splitline)
     lenold=len(processingmodules)
     if (splitline[0]=="LayerRouter:") :
         processingmodules.append([1,splitline[1]])
@@ -121,9 +121,9 @@ for line in fi :
         processingcounts[processingmodules[len(processingmodules)-1][0]-1]+=1
 
 for x in processingmodules :
-    print "processingmodules : ",x
+    print("processingmodules : ",x)
 
-print processingcounts
+print(processingcounts)
 
 xmemories=[0.005,0.065,0.145,0.26,0.37,0.495,0.60,0.72,0.82,0.90,0.975]
 dxmemories=[0.015,0.02,0.03,0.05,0.05,0.05,0.05,0.045,0.03,0.025,0.025]
@@ -140,7 +140,7 @@ for module in memorymodules :
     module.append([x,y,x+dx,y])
     fo.write("Memory "+module[1])
     fo.write(" "+str(x)+" "+str(y)+" "+str(x+dx)+" "+str(y)+"\n")
-    print module
+    print(module)
 
 
 xprocessing=[0.03,0.10,0.20,0.32,0.44,0.56,0.67,0.78,0.865,0.945]
@@ -156,7 +156,7 @@ for module in processingmodules :
     module.append([x,y,x+dx,y])
     fo.write("Process "+module[1].split("\n")[0])
     fo.write(" "+str(x)+" "+str(y)+" "+str(x+dx)+" "+str(y)+"\n")
-    print module
+    print(module)
 
 fi = open("wires.dat","r")
 for line in fi :
@@ -166,7 +166,7 @@ for line in fi :
     inprocess=line.split("input=> ")[1].split(" ")[0].split(".")[0]    
     outprocess=line.split("output=> ")[1].split("\n")[0].split(".")[0]
 
-    print memory+" in: "+inprocess+" out: "+outprocess
+    print(memory+" in: "+inprocess+" out: "+outprocess)
 
     #Find the memory module
     memmodule=[]
@@ -174,8 +174,8 @@ for line in fi :
         if (mem[1]==memory) :
             memmodule=mem
     if (memmodule==[]) :
-        print "Could not find memorymodule: ",memory
-        print "Will terminate"
+        print("Could not find memorymodule: ",memory)
+        print("Will terminate")
         exit()
 
     last=len(memmodule)-1
@@ -184,14 +184,14 @@ for line in fi :
     if (inprocess!="") :
         procmodule=[]        
         for proc in processingmodules :
-            #print "Comparing ",proc[1].split("\n")[0]," - ",inprocess
+            #print("Comparing ",proc[1].split("\n")[0]," - ",inprocess)
             if (proc[1].split("\n")[0]==inprocess) :
                 procmodule=proc
         if (procmodule==[]) :
-            print "Could not find in processingmodule: ",inprocess
-            print "Will terminate"
+            print("Could not find in processingmodule: ",inprocess)
+            print("Will terminate")
             exit()
-        print "memmodule[0], procmodule[0] : ", memmodule[0],procmodule[0]    
+        print("memmodule[0], procmodule[0] : ", memmodule[0],procmodule[0]    )
         if (memmodule[0]==procmodule[0]+1 or memmodule[0]==procmodule[0]) :
             fo.write("Line "+str(procmodule[2][2])+" "+str(procmodule[2][3]))
             fo.write(" "+str(memmodule[last][0])+" "+str(memmodule[last][1])+"\n")
@@ -201,12 +201,12 @@ for line in fi :
     if (outprocess!="") :    
         procmodule=[]        
         for proc in processingmodules :
-            #print "Comparing ",proc[1].split("\n")[0]," - ",outprocess
+            #print("Comparing ",proc[1].split("\n")[0]," - ",outprocess)
             if (proc[1].split("\n")[0]==outprocess) :
                 procmodule=proc
         if (procmodule==[]) :
-            print "Could not find outprocessingmodule: ",outprocess
-            print "Will terminate"
+            print("Could not find outprocessingmodule: ",outprocess)
+            print("Will terminate")
             exit()
         if (memmodule[0]==procmodule[0] or memmodule[0]==procmodule[0]-1) :
             fo.write("Line "+str(procmodule[2][0])+" "+str(procmodule[2][1]))

--- a/Graph.py
+++ b/Graph.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
+
 import math
 
 fi = open("memorymodules.dat","r")

--- a/GraphAnalyzer.py
+++ b/GraphAnalyzer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, TrackletGraph
 from ROOT import TH1I, TCanvas, gPad
 import argparse

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ after running the Wires.py script by doing
 -----------------------------------------------------------------
 
 ## Python version and other dependencies
-This code is currently not compatible with python 3. Some of the code also depends on ROOT and its 
-python interface (last tested with version 6.10.00).
+This code is compatible with python 2 or 3.  All new code should be compatible with python 3; since python 2 has ended support in 2020.
 
-There are no other dependencies.
+Some of the code also depends on ROOT and its python interface (last tested with version 6.10.00), though this can be disabled via the `--no-graph` option.
 
+The 'future' package is required (i.e., `conda install future` if you use anaconda python distribution.)
 -----------------------------------------------------------------
 
 ## Technical details of scripts for producing wiring files.

--- a/SubGraph.py
+++ b/SubGraph.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from __future__ import print_function
 import math
 import sys
 

--- a/SubGraph.py
+++ b/SubGraph.py
@@ -4,13 +4,13 @@ import math
 import sys
 
 if (len(sys.argv) != 2 ) :
-    print "Usage: SubGraph.py <proc. module>"
-    print len(sys.argv)
-    print sys.argv[0]
-    print sys.argv[1]
+    print("Usage: SubGraph.py <proc. module>")
+    print(len(sys.argv))
+    print(sys.argv[0])
+    print(sys.argv[1])
     exit(1)
 
-print 'Will read wires.dat'
+print('Will read wires.dat')
  
 #Build the geometry for layers
 
@@ -24,7 +24,7 @@ for line in fi:
         continue
     substr = line.split("=>")
     if len(substr) != 3 :
-        print substr
+        print(substr)
     subsubstr=substr[0].split()
     if sys.argv[1] in substr[1]:
         inputmemorymodules.append(subsubstr[0])

--- a/SubGraph.py
+++ b/SubGraph.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import math
 import sys
 

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -429,7 +429,7 @@ class TrackletGraph(object):
             p_dict: processing module dictionary
             m_dict: memory module dictionary
         """
-        for m in m_dict.keys():
+        for m in list(m_dict.keys()): # py3 doesn't make a copy of list of keys, like py2
             if not m.startswith("TF_"):
                 continue
             seed = m.split("_")[1]

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 import math
 import copy

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -1,6 +1,7 @@
 import re
 import math
 import copy
+from six.moves import range
 
 #######################################
 # Ordering of the processing steps

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import division
 import re
 import math
 import copy
-from six.moves import range
+from builtins import range
 
 #######################################
 # Ordering of the processing steps

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -127,7 +127,7 @@ class MemTypeInfoByKey(object):
                 self.mixedIO = True
         assert(len(keySet) == 1) # Ensure only one key name is input memory list.
         if self.mixedIO and self.is_initial:
-            print "ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some inputs connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT"
+            print("ERROR: Memories of type ",self.mtype_short," in chain have mixed I/O: some inputs connected to chain & some to external ports. NOT YET SUPPORTED BY SCRIPT")
             exit(1)
 
 
@@ -584,7 +584,7 @@ class TrackletGraph(object):
             return self.__proc_dict[instance_name]
         else:
             if verbose:
-                print "WARNING!! Cannot find module", instance_name,"!!"
+                print("WARNING!! Cannot find module", instance_name,"!!")
             return None
 
     def get_all_module_units(self, module):
@@ -594,7 +594,7 @@ class TrackletGraph(object):
             if instance_name.startswith(module+"_"):
                 modules[instance_name]=self.__proc_dict[instance_name]
         if not modules:
-            print "WARNING!! Cannot find any modules", instance_name,"!!"
+            print("WARNING!! Cannot find any modules", instance_name,"!!")
         else:
             return modules
 
@@ -604,7 +604,7 @@ class TrackletGraph(object):
             return self.__mem_dict[instance_name]
         else:
             if verbose:
-                print "Cannot find module", instance_name
+                print("Cannot find module", instance_name)
             return None
     
     def get_module(self, instance_name):
@@ -614,9 +614,9 @@ class TrackletGraph(object):
         # if not, try memory modules
         if aModule is None:
             aModule = self.get_mem_module(instance_name, verbose=False)
-        # if still no, print warning
+        # if still no, print(warning)
         if aModule is None:
-            print "TrackletGraph: Cannot find module", instance_name
+            print("TrackletGraph: Cannot find module", instance_name)
 
         return aModule
     
@@ -982,5 +982,5 @@ class TrackletGraph(object):
         dyBox = 0.5/(math.log(maxnum)*10)
         textSize = 0.5/(math.log(maxnum)*10+1)
 
-        # print  pageWidth, pageHeight, dyBox, textSize, maxnum
+        # print( pageWidth, pageHeight, dyBox, textSize, maxnum)
         return int(pageWidth), int(pageHeight), dyBox, textSize

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -84,6 +84,8 @@ class MemModule(Node):
         self.has_numEntries_out = True # True if has numEntries out port.
     def keyName(self): # All mems with same keyName made in same VHDL "generate" loop.
         return self.mtype_short()+"_"+str(self.bitwidth)
+    def __lt__(self, other) : # py3 needs this explicitly for ordering
+        return self.inst < other.inst ### lexical sort on instance name
 
 class ProcModule(Node):
     def __init__(self, module_type, instance_name, index):

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 import re
 import math
 import copy

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -3,9 +3,9 @@
 # Utilities for writing Verilog code from Vivado HLS blocks
 """
 from __future__ import print_function
+from __future__ import absolute_import
 
 #from collections import deque
-from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
 
 from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeProcTrackStreamLHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts
@@ -13,7 +13,6 @@ import re
 # This dictionary preserves key order. 
 # (Requires python >= 2.7. And can be replace with normal dict for >= 3.7)
 from collections import OrderedDict
-from six.moves import zip
 
 def getMemoryClassName_InputStub(instance_name):
     """
@@ -275,6 +274,9 @@ def getListsOfGroupedMemories(aProcModule):
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
     # Sort the VMSME and VMSTE using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
+    # zipped_list = zip(memList, portList)
+    # zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else int("".join([i for i in p if i.isdigit()]))) # sort by number
+    # zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else p[:p.index('PHI')]) # sort alphabetically
     zipped_list = list(zip(memList, portList))
     zipped_list.sort(key=lambda m_p: 0 if 'vmstubout' else int("".join([i for i in m_p[1] if i.isdigit()]))) # sort by number
     zipped_list.sort(key=lambda m_p1: 0 if 'vmstubout' else m_p1[1][:m_p1[1].index('PHI')]) # sort alphabetically

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -4,6 +4,7 @@
 """
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division
 
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -11,6 +11,7 @@ import re
 # This dictionary preserves key order. 
 # (Requires python >= 2.7. And can be replace with normal dict for >= 3.7)
 from collections import OrderedDict
+from six.moves import zip
 
 def getMemoryClassName_InputStub(instance_name):
     """
@@ -272,10 +273,10 @@ def getListsOfGroupedMemories(aProcModule):
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
     # Sort the VMSME and VMSTE using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
-    zipped_list = zip(memList, portList)
-    zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else int("".join([i for i in p if i.isdigit()]))) # sort by number
-    zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else p[:p.index('PHI')]) # sort alphabetically
-    memList, portList = zip(*zipped_list) # unzip
+    zipped_list = list(zip(memList, portList))
+    zipped_list.sort(key=lambda m_p: 0 if 'vmstubout' else int("".join([i for i in m_p[1] if i.isdigit()]))) # sort by number
+    zipped_list.sort(key=lambda m_p1: 0 if 'vmstubout' else m_p1[1][:m_p1[1].index('PHI')]) # sort alphabetically
+    memList, portList = list(zip(*zipped_list)) # unzip
     memList, portList = list(memList), list(portList)
 
     return memList, portList

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -326,7 +326,7 @@ def matchArgPortNames_IR(argname, portname, memoryname):
     elif 'hPhBnWord' in argname or 'hLinkWord' in argname:
         return False
     else:
-        print "matchArgPortNames_IR: Unknown argument", argname
+        print("matchArgPortNames_IR: Unknown argument", argname)
         return False
 
 # Dictionary with the number of memories per layer/disk. Needed for the InputRouter
@@ -382,7 +382,7 @@ def matchArgPortNames_VMR(argname, portname, memoryname):
     elif 'mask' in argname or 'Table' in argname:
         return False
     else:
-        print "matchArgPortNames_VMR: Unknown argument", argname
+        print("matchArgPortNames_VMR: Unknown argument", argname)
         return False
 
 ################################
@@ -402,7 +402,7 @@ def matchArgPortNames_TE(argname, portname, memoryname):
     elif argname == 'outstubpair':
         return portname == 'stubpairout' or 'stubPairs_' in portname
     else:
-        print "matchArgPortNames_TE: Unknown argument name", argname
+        print("matchArgPortNames_TE: Unknown argument name", argname)
         return False
 
 ################################
@@ -516,7 +516,7 @@ def matchArgPortNames_TC(argname, portname, memoryname):
         elif destination == "2s":
             return portname[7:9] in ["L4", "L5", "L6"]
     else:
-        print "matchArgPortNames_TC: Unknown argument", argname
+        print("matchArgPortNames_TC: Unknown argument", argname)
         return False
 
 def decodeSeedIndex_TC(memoryname):
@@ -561,7 +561,7 @@ def decodeSeedIndex_TC(memoryname):
     elif ('D5PHID' in memoryname):
         return 19
     else:
-        print "decodeSeedIndex_TC: Unknown memory name", memoryname
+        print("decodeSeedIndex_TC: Unknown memory name", memoryname)
         return False
 
 
@@ -610,7 +610,7 @@ def matchArgPortNames_PR(argname, portname, memoryname):
     elif 'vmprojout' in argname:
         return 'vmprojout' in portname
     else:
-        print "matchArgPortNames_PR: Unknown argument", argname
+        print("matchArgPortNames_PR: Unknown argument", argname)
         return False
 
 ################################
@@ -651,7 +651,7 @@ def matchArgPortNames_ME(argname, portname, memoryname):
     elif argname == 'outputCandidateMatch':
         return portname == 'matchout'
     else:
-        print "matchArgPortNames_ME: Unknown argument name", argname
+        print("matchArgPortNames_ME: Unknown argument name", argname)
         return False
 
 ################################
@@ -699,7 +699,7 @@ def matchArgPortNames_MC(argname, portname, memoryname):
     elif 'match' in argname:
         return 'match' in portname and 'out' not in portname
     else:
-        print "matchArgPortNames_MC: Unknown argument name", argname
+        print("matchArgPortNames_MC: Unknown argument name", argname)
         return False
 
 # Temporary bodge to get the correct argname index for the fullmatch memories
@@ -721,7 +721,7 @@ def decodeSeedIndex_MC(memoryname):
     elif 'L2D1' in memoryname:
         return 7
     else:
-        print "decodeSeedIndex_MC: Unknown memory name", memoryname
+        print("decodeSeedIndex_MC: Unknown memory name", memoryname)
         return False
 
 ################################
@@ -760,7 +760,7 @@ def matchArgPortNames_TB(argname, portname, memoryname):
         return portname.startswith("barrelstub")
     if argname.startswith("diskStubWords"):
         return portname.startswith("diskstub")
-    print "matchArgPortNames_TB: Unknown argument name", argname
+    print("matchArgPortNames_TB: Unknown argument name", argname)
     return False
 
 ################################
@@ -837,7 +837,7 @@ def parseProcFunction(proc_name, fname_def):
     templ_pars_list = []
     
     if procfunc_str == "":
-        print "Cannot find processing function", proc_name, "in", fname_def
+        print("Cannot find processing function", proc_name, "in", fname_def)
         return arg_types_list, arg_names_list, templ_pars_list
     
     # get the argument lists
@@ -870,8 +870,8 @@ def parseProcFunction(proc_name, fname_def):
 
     # get the template parameter list
     if template_buffer == "":
-        print "No template parameters are found."
-        print "Please make sure the processing function", proc_name, "is templatized in", fname_def
+        print("No template parameters are found.")
+        print("Please make sure the processing function", proc_name, "is templatized in", fname_def)
         return arg_types_list, arg_names_list, templ_pars_list
     
     templPars_str = template_buffer.split("<")[1].split(">")[0]

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -275,9 +275,6 @@ def getListsOfGroupedMemories(aProcModule):
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
     # Sort the VMSME and VMSTE using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
-    # zipped_list = zip(memList, portList)
-    # zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else int("".join([i for i in p if i.isdigit()]))) # sort by number
-    # zipped_list.sort(key=lambda (m, p): 0 if 'vmstubout' else p[:p.index('PHI')]) # sort alphabetically
     zipped_list = list(zip(memList, portList))
     zipped_list.sort(key=lambda m_p: 0 if 'vmstubout' else int("".join([i for i in m_p[1] if i.isdigit()]))) # sort by number
     zipped_list.sort(key=lambda m_p1: 0 if 'vmstubout' else m_p1[1][:m_p1[1].index('PHI')]) # sort alphabetically
@@ -424,7 +421,7 @@ def writeTemplatePars_TC(aTCModule):
     NASMemOuter = 0  # number of outer allstub memories
     PhiLabelASInner = []
     PhiLabelASOuter = []
-    for inmem, portname in zip(aTCModule.upstreams, aTCModule.input_port_names):
+    for inmem, portname in list(zip(aTCModule.upstreams, aTCModule.input_port_names)):
         if 'innerallstub' in portname:
             NASMemInner += 1
             # AS memory instance name example: AS_L1PHICn3
@@ -445,7 +442,7 @@ def writeTemplatePars_TC(aTCModule):
     # Count StubPair memories
     NSPMem = [[0,0],[0,0]]
 
-    for inmem, portname in zip(aTCModule.upstreams, aTCModule.input_port_names):
+    for inmem, portname in list(zip(aTCModule.upstreams, aTCModule.input_port_names)):
         if 'stubpair' in portname:
             sp_instance = inmem.inst
             # stubpair memory instance name example: SP_L1PHIB8_L2PHIA7
@@ -473,7 +470,7 @@ def writeTemplatePars_TC(aTCModule):
 
     TPROJMask = 0
     
-    for outmem, portname in zip(aTCModule.downstreams, aTCModule.output_port_names):
+    for outmem, portname in list(zip(aTCModule.downstreams, aTCModule.output_port_names)):
         if 'projout' in portname: # portname example: projoutL6PHID
             layer = portname[7:9] # L6
             phi = portname[-1] # D
@@ -944,7 +941,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     array_dict = {}
 
     # loop over the list of argument names from parsing the header file
-    for argtype, argname in zip(argtypes, argnames):
+    for argtype, argname in list(zip(argtypes, argnames)):
         # bunch crossing
         if argtype == "BXType":
             for mem in module.upstreams:
@@ -967,7 +964,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
         else:
             # Given argument name, search for the matched port name in the mem lists
             foundMatch = False
-            for memory, portname in zip(memModuleList, portNameList):
+            for memory, portname in list(zip(memModuleList, portNameList)):
                 # Check if the portname matches the argument name from function def
                 if f_matchArgPortNames is None:
                     # No matching rule provided, just check if the names are the same

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 #from collections import deque
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
 
 from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeProcTrackStreamLHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -2,6 +2,7 @@
 ########################################
 # Utilities for writing Verilog code from Vivado HLS blocks
 """
+from __future__ import print_function
 
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -2,6 +2,7 @@
 # Utilities for writing Vivado HLS code
 ########################################
 #from collections import deque
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule
 from six.moves import zip
 

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -3,6 +3,7 @@
 ########################################
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule
+from six.moves import zip
 
 ########################################
 # Memory objects

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from TrackletGraph import MemModule, ProcModule
-from six.moves import zip
 
 ########################################
 # Memory objects

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -4,6 +4,7 @@
 #from collections import deque
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import division
 from TrackletGraph import MemModule, ProcModule
 
 ########################################

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -468,7 +468,7 @@ def matchArgPortNames_TC(argname, portname):
         destination = argname.strip().split('_')[-1]
         return destination in portname and 'projout' in portname
     else:
-        print "matchArgPortNames_TC: Unknown argument", argname
+        print("matchArgPortNames_TC: Unknown argument", argname)
         return False
 
 ################################
@@ -532,7 +532,7 @@ def matchArgPortNames_PR(argname, portname):
         X_arg = int(argname[9:])
         return X_arg == X_port
     else:
-        print "matchArgPortNames_PR: Unknown argument", argname
+        print("matchArgPortNames_PR: Unknown argument", argname)
         return False
     
 ################################
@@ -554,7 +554,7 @@ def writeTemplatePars_ME(aMEModule):
         else:
             VMSTYPE = 'BARRELPS'
     else:  # Disk
-        print "WARNING! Disk MatchEngine is not supported yet!"
+        print("WARNING! Disk MatchEngine is not supported yet!")
         DISK = pos[1]
         VMSTYPE = 'DISK'
 
@@ -572,7 +572,7 @@ def matchArgPortNames_ME(argname, portname):
     elif argname == 'outcandmatch':
         return portname == 'matchout'
     else:
-        print "matchArgPortNames_ME: Unknown argument name", argname
+        print("matchArgPortNames_ME: Unknown argument name", argname)
         return False
 
 ################################
@@ -621,7 +621,7 @@ def matchArgPortNames_MC(argname, portname):
     elif argname == 'fullmatch2':
         return portname == 'matchout2'
     else:
-        print "matchArgPortNames_MC: Unknow argument name", argname
+        print("matchArgPortNames_MC: Unknow argument name", argname)
         return False
 
 ################################
@@ -707,7 +707,7 @@ def parseProcFunction(proc_name, fname_def):
     templ_pars_list = []
     
     if procfunc_str == "":
-        print "Cannot find processing function", proc_name, "in", fname_def
+        print("Cannot find processing function", proc_name, "in", fname_def)
         return arg_types_list, arg_names_list, templ_pars_list
     
     # get the argument lists
@@ -732,8 +732,8 @@ def parseProcFunction(proc_name, fname_def):
 
     # get the template parameter list
     if template_buffer == "":
-        print "No template parameters are found."
-        print "Please make sure the processing function", proc_name, "is templatized in", fname_def
+        print("No template parameters are found.")
+        print("Please make sure the processing function", proc_name, "is templatized in", fname_def)
         return arg_types_list, arg_names_list, templ_pars_list
     
     templPars_str = template_buffer.split("<")[1].split(">")[0]

--- a/WriteHLSUtils.py
+++ b/WriteHLSUtils.py
@@ -3,6 +3,7 @@
 ########################################
 #from collections import deque
 from __future__ import absolute_import
+from __future__ import print_function
 from TrackletGraph import MemModule, ProcModule
 from six.moves import zip
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,4 +1,5 @@
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
+from six.moves import range
 
 def writeTopPreamble(all=True):
     string_preamble = "--! Standard libraries\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
 from six.moves import range
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
+from builtins import range
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
-from six.moves import range
 
 def writeTopPreamble(all=True):
     string_preamble = "--! Standard libraries\n"

--- a/WriteVLOGSyntax.py
+++ b/WriteVLOGSyntax.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from six.moves import range
 def writeTopPreamble():
     string_preamble = "`timescale 1ns / 1ps\n\n"

--- a/WriteVLOGSyntax.py
+++ b/WriteVLOGSyntax.py
@@ -1,3 +1,4 @@
+from six.moves import range
 def writeTopPreamble():
     string_preamble = "`timescale 1ns / 1ps\n\n"
     return string_preamble

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -511,25 +511,25 @@ if __name__ == "__main__":
     fout_tcl.write(string_tcl)
 
     ###############
-    print "Output top file:", fname_top
-    print "Output test bench file:", fname_tb
-    print "Output HDL package:", fname_memUtil
-    print "Output tcl script:", fname_tcl
+    print("Output top file:", fname_top)
+    print("Output test bench file:", fname_tb)
+    print("Output HDL package:", fname_memUtil)
+    print("Output tcl script:", fname_tcl)
     
     ###############
     # Copy the necessary emulation memory printouts for test bench
     # make a local directory first
 #    if os.path.exists(args.memprint_dir):
-#        print "Creating a directory:", args.emData_dir
+#        print("Creating a directory:", args.emData_dir)
 #        subprocess.call(['mkdir','-p',args.emData_dir])
 #
-#        print "Start to copy emulation printouts locally"
+#        print("Start to copy emulation printouts locally")
 #        for filename in list_memprints:
 #            memdir = getMemPrintDirectory(filename)+'/'
 #            fullname = args.memprint_dir.rstrip('/')+'/'+memdir+filename
 #            subprocess.call(['cp', fullname, args.emData_dir+'/.'])
-#        print "Done copying emulation printouts"
+#        print("Done copying emulation printouts")
 #    else:
-#        print "Cannot find directory", args.memprint_dir
-#        print "No memory prinout files are copied."
+#        print("Cannot find directory", args.memprint_dir)
+#        print("No memory prinout files are copied.")
     

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -73,7 +73,6 @@ def writeProcModules(proc_list, hls_src_dir, extraports):
     proc_type_list = []
 
     for aProcMod in proc_list:
-        print("procname"+ aProcMod.inst)
         if not aProcMod.mtype in proc_type_list: # Is this aProcMod the first of its type
             proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports)
             proc_type_list.append(aProcMod.mtype)

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -6,6 +6,7 @@
 # N.B. Check hard-wired constants in TrackletGraph::populate_bitwidths()
 ################################################
 from __future__ import absolute_import
+from __future__ import print_function
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey, TrackletGraph
 from WriteHDLUtils import arrangeMemoriesByKey, \
                             writeModuleInstance

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -7,6 +7,12 @@
 ################################################
 from __future__ import absolute_import
 from __future__ import print_function
+
+try:
+    from rich.traceback import install
+    install()
+except:
+    pass
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey, TrackletGraph
 from WriteHDLUtils import arrangeMemoriesByKey, \
                             writeModuleInstance
@@ -67,6 +73,7 @@ def writeProcModules(proc_list, hls_src_dir, extraports):
     proc_type_list = []
 
     for aProcMod in proc_list:
+        print("procname"+ aProcMod.inst)
         if not aProcMod.mtype in proc_type_list: # Is this aProcMod the first of its type
             proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports)
             proc_type_list.append(aProcMod.mtype)

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -5,6 +5,7 @@
 #
 # N.B. Check hard-wired constants in TrackletGraph::populate_bitwidths()
 ################################################
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey, TrackletGraph
 from WriteHDLUtils import arrangeMemoriesByKey, \
                             writeModuleInstance

--- a/generator_vhls.py
+++ b/generator_vhls.py
@@ -436,25 +436,25 @@ if __name__ == "__main__":
     fout_tcl.write(string_tcl)
 
     ###############
-    print "Output source file:", fname_src
-    print "Output header file:", fname_header
-    print "Output test bench file:", fname_tb
-    print "Output tcl script:", fname_tcl
+    print("Output source file:", fname_src)
+    print("Output header file:", fname_header)
+    print("Output test bench file:", fname_tb)
+    print("Output tcl script:", fname_tcl)
     
     ###############
     # Copy the necessary emulation memory printouts for test bench
     # make a local directory first
     if os.path.exists(args.memprint_dir):
-        print "Creating a directory:", args.emData_dir
+        print("Creating a directory:", args.emData_dir)
         subprocess.call(['mkdir','-p',args.emData_dir])
 
-        print "Start to copy emulation printouts locally"
+        print("Start to copy emulation printouts locally")
         for filename in list_memprints:
             memdir = getMemPrintDirectory(filename)+'/'
             fullname = args.memprint_dir.rstrip('/')+'/'+memdir+filename
             subprocess.call(['cp', fullname, args.emData_dir+'/.'])
-        print "Done copying emulation printouts"
+        print("Done copying emulation printouts")
     else:
-        print "Cannot find directory", args.memprint_dir
-        print "No memory prinout files are copied."
+        print("Cannot find directory", args.memprint_dir)
+        print("No memory prinout files are copied.")
     

--- a/generator_vhls.py
+++ b/generator_vhls.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 from TrackletGraph import MemModule, ProcModule, TrackletGraph
 from WriteHLSUtils import getHLSMemoryClassName, groupAllConnectedMemories, writeMemoryInstance, writeProcFunction
 import os, subprocess

--- a/generator_vhls.py
+++ b/generator_vhls.py
@@ -3,6 +3,7 @@
 from TrackletGraph import MemModule, ProcModule, TrackletGraph
 from WriteHLSUtils import getHLSMemoryClassName, groupAllConnectedMemories, writeMemoryInstance, writeProcFunction
 import os, subprocess
+from __future__ import print_function
 
 ########################################
 # Functions to write strings

--- a/generator_vhls.py
+++ b/generator_vhls.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+from __future__ import print_function
 from TrackletGraph import MemModule, ProcModule, TrackletGraph
 from WriteHLSUtils import getHLSMemoryClassName, groupAllConnectedMemories, writeMemoryInstance, writeProcFunction
 import os, subprocess
-from __future__ import print_function
 
 ########################################
 # Functions to write strings

--- a/makeReducedConfig.py
+++ b/makeReducedConfig.py
@@ -160,7 +160,7 @@ class project:
         lxphis = ["A", "B", "C", "D"]
 
         if tc.upper() not in tcs:
-            print "Bad TC index, not adding."
+            print("Bad TC index, not adding.")
             return
 
         # Store whether or not we're including negative eta inputs
@@ -174,7 +174,7 @@ class project:
         phi1_i = int(tc_i*1.*len(l1phis)/len(tcs))
         phix_i = int(tc_i*1.*len(lxphis)/len(tcs))
 
-        print "Adding regions to project: TC_%s%s, L1PHI%s, LxPHI%s"%(tcs[tc_i], layers, l1phis[phi1_i], lxphis[phix_i])
+        print("Adding regions to project: TC_%s%s, L1PHI%s, LxPHI%s"%(tcs[tc_i], layers, l1phis[phi1_i], lxphis[phix_i]))
         self.tcs.append("TC_%s%s"%(layers,tcs[tc_i]))
         self.l1phis.append(l1phis[phi1_i])
         self.lxphis.append(lxphis[phix_i])
@@ -183,23 +183,23 @@ class project:
         # Starting with e.g. TC_L1L2F and moving up and down the chain
         # For each node it adds, will check for all inputs and outputs of that node
 
-        print "Starting with node TC_%s%s"%(layers,tcs[tc_i])
+        print("Starting with node TC_%s%s"%(layers,tcs[tc_i]))
         n = node("TC_%s%s"%(layers,tcs[tc_i]))
         self.addNode(n)
-        print "Finding inputs..."
+        print("Finding inputs...")
         self.findInputConnections(n, ref_p)
-        print "Finding outputs..."
+        print("Finding outputs...")
         self.findOutputConnections(n, ref_p)
 
     def findInputConnections(self, n, ref_p):
-        if verbose: print "\t", n.name
+        if verbose: print("\t", n.name)
         ref_node = ref_p.nodes[n.name]
         ref_inputs = ref_node.getInputConnections()
-        if verbose: print "\tInputs:", ["%s -> %s"%(r.cinput.name, r.coutput.name) for r in ref_inputs]
+        if verbose: print("\tInputs:", ["%s -> %s"%(r.cinput.name, r.coutput.name) for r in ref_inputs])
         for ref_c in ref_inputs:
             ref_n = ref_c.cinput
             if self.isIncluded(ref_n, ref_c.memory):
-                if verbose: print "\t\t", "Found good input!:", ref_n.name
+                if verbose: print("\t\t", "Found good input!:", ref_n.name)
                 in_n = node(ref_n.name)
                 in_c = connection(ref_c.memory, in_n, n, ref_c.cinext, ref_c.coutext)
                 n.addConnection(in_c)
@@ -213,14 +213,14 @@ class project:
                         self.findOutputConnections(in_n, ref_p)
 
     def findOutputConnections(self, n, ref_p):
-        if verbose: print "\t", n.name
+        if verbose: print("\t", n.name)
         ref_node = ref_p.nodes[n.name]
         ref_outputs = ref_node.getOutputConnections()
-        if verbose: print "\tOutputs:", ["%s -> %s"%(r.cinput.name, r.coutput.name) for r in ref_outputs]
+        if verbose: print("\tOutputs:", ["%s -> %s"%(r.cinput.name, r.coutput.name) for r in ref_outputs])
         for ref_c in ref_outputs:
             ref_n = ref_c.coutput
             if self.isIncluded(ref_n, ref_c.memory):
-                if verbose: print "\t\t", "Found good output!:", ref_n.name
+                if verbose: print("\t\t", "Found good output!:", ref_n.name)
                 out_n = node(ref_n.name)
                 out_c = connection(ref_c.memory, n, out_n, ref_c.cinext, ref_c.coutext)
                 n.addConnection(out_c)
@@ -296,13 +296,13 @@ parser.set_defaults(graph=True)
 args = parser.parse_args()
 
 # Load in full project
-print "Loading full wire project..."
+print("Loading full wire project...")
 full_wires = project()
 full_wires.loadProject(args.wires)
 #full_wires.saveProject("test.dat")
 
 # Set up reduced project and give it a phi sector in L1
-print "Finding reduced configuration..."
+print("Finding reduced configuration...")
 reduced_wires = project()
 reduced_wires.addRefModules(args.process)
 reduced_wires.addRefMemories(args.memories)

--- a/makeReducedConfig.py
+++ b/makeReducedConfig.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 from __future__ import print_function
+from __future__ import division
+
 from TrackletGraph import TrackletGraph
 import argparse
 from collections import OrderedDict

--- a/makeReducedConfig.py
+++ b/makeReducedConfig.py
@@ -3,6 +3,7 @@
 from TrackletGraph import TrackletGraph
 import argparse
 from collections import OrderedDict
+from __future__ import print_function
 
 # Creates a reduced configuration when given a TC phi region
 # Takes a full configuration as input

--- a/makeReducedConfig.py
+++ b/makeReducedConfig.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
+from __future__ import print_function
 from TrackletGraph import TrackletGraph
 import argparse
 from collections import OrderedDict
-from __future__ import print_function
 
 # Creates a reduced configuration when given a TC phi region
 # Takes a full configuration as input


### PR DESCRIPTION
Add support for python3, while maintaining support for python 2. This code requires python3 > 3.6.

The biggest changes are

- change in how zip is handled, especially for when iterating over lists that change
- changes in how lambda functions are handled with tuple arguments
- adapt all uses of print to print() (`from __future__ import print_function`)
- ensure that all integer division is the same (`from __future__ import division`)
- other somewhat mysterious import that the interwebs tell me is needed (`from __future__ import absolute_import`)

I compared the output of the following command between python 2 on the master branch and python 2 and 3 on this branch and diff'd the files. No difference.
```
./generator_hdl.py ~/src/firmware-hls --uut TC_L1L2E -u 1 -d 0  --no-graph
```
This is probably not exhaustive; anyone have other tests I should run?

I didn't check the `root` stuff in python 2 or 3 since I don't have that on this machine.

I also added a github action to test if newly added code is compatible with python3 or not, to ensure we don't have any regression. 