### PR TITLE
Fix issue that VHDL variables cant start with number

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -58,6 +58,9 @@ class Node(object):
     def __init__(self, module_type, instance_name, i):
         self.mtype = module_type # Module type (e.g. "TrackletProjections")
         self.inst = instance_name
+        # Bodge to prevent VHDL enums starting with a number, which is illegal.
+        if (self.inst.startswith("DL_2S")):
+            self.inst = self.inst.replace("DL_2S","DL_SS")
         self.upstreams = [] # list of pointers to upstream Nodes
         self.downstreams = [] # list of pointers to downstream Nodes
         self.index = i  # instance index from the configuration file
@@ -498,6 +501,9 @@ class TrackletGraph(object):
                     portname = "diskstub"
                     index = diskIndex
                     diskIndex += 1
+                # Avoid all SW having same index, as sorted by them later.
+                new_mem.index += 0.01*barrelIndex + 0.1*diskIndex;
+
                 m_dict[new_mem.inst] = new_mem
                 if up_p is not None:
                     up_p.downstreams.append(new_mem)

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -60,7 +60,7 @@ class Node(object):
         self.inst = instance_name
         # Bodge to prevent VHDL enums starting with a number, which is illegal.
         if (self.inst.startswith("DL_2S")):
-            self.inst = self.inst.replace("DL_2S","DL_SS")
+            self.inst = self.inst.replace("DL_2S","DL_twoS")
         self.upstreams = [] # list of pointers to upstream Nodes
         self.downstreams = [] # list of pointers to downstream Nodes
         self.index = i  # instance index from the configuration file

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -208,8 +208,8 @@ def writeMemoryUtil(memDict, memInfoDict):
         for mem in memList:
             newvar = mem.var()
             # Bodge explained in TrackletGraph::Node()
-            if (mem.inst.startswith("DL_SS")):
-                newvar = newvar.replace("SS","2S")
+            if (mem.inst.startswith("DL_twoS")):
+                newvar = newvar.replace("twoS","2S")
             ss += "       when "+mem.var()+" => return \""+newvar+"\";\n"
         ss += "    end case;\n"
         ss += "    return \"No conversion found.\";\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -206,7 +206,11 @@ def writeMemoryUtil(memDict, memInfoDict):
         ss += "  begin\n"
         ss += "    case val is\n"
         for mem in memList:
-            ss += "       when "+mem.var()+" => return \""+mem.var()+"\";\n"
+            newvar = mem.var()
+            # Bodge explained in TrackletGraph::Node()
+            if (mem.inst.startswith("DL_SS")):
+                newvar = newvar.replace("SS","2S")
+            ss += "       when "+mem.var()+" => return \""+newvar+"\";\n"
         ss += "    end case;\n"
         ss += "    return \"No conversion found.\";\n"
         ss += "  end memory_enum_to_string;\n\n"


### PR DESCRIPTION
1) Fixes issue https://github.com/cms-L1TK/project_generation_scripts/issues/33 .

2) Also fixes issue that TrackWord & StubWords from created from a TrackFitMemory all have the same memory.index, so when the code sorts the memories by this index, their order is random. This avoids the issue that the order of these items in memUtils.vhd changed randomly when one modified unrelated parts of the python scripts.
