### PR TITLE
Generate testbench

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Example for IR-VMR chain:
 ```
 Example for "reduced" IR-VMR-TE-TC-PR-ME-MC-TB chain
 ```
-generator_hdl.py --mut IR -u 0 -d 7 -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat
+./generator_hdl.py --mut IR -u 0 -d 7 -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat
 ```
 *dirHLS* is the location of the HLS code, which defaults to "../firmware-hls".
 

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -8,16 +8,18 @@ from builtins import range
 
 #######################################
 # Ordering of the processing steps
-#ProcOrder_dict = {
-#    'VMRouter':1,
-#    'TrackletEngine':2,
-#    'TrackletCalculator':3,
-#    'ProjectionRouter':4,
-#    'MatchEngine':5,
-#    'MatchCalculator':6,
-#    'FitTrack':7,
-#    'PurgeDuplicate':8
-#}
+ProcOrder_dict = {
+   'InputRouter':0,
+   'VMRouter':1,
+   'TrackletEngine':2,
+   'TrackletCalculator':3,
+   'ProjectionRouter':4,
+   'MatchEngine':5,
+   'MatchCalculator':6,
+   'FitTrack':7,
+   'PurgeDuplicate':8,
+   'TrackBuilder':9
+}
 # TODO: Should be able to generate this from the wiring
 #######################################
 # Drawing parameters
@@ -95,7 +97,7 @@ class ProcModule(Node):
     def __init__(self, module_type, instance_name, index):
         Node.__init__(self, module_type, instance_name, index)
         self.parameters = {} # dictionary of parameters
-        #self.order = ProcOrder_dict[module_type]
+        self.order = ProcOrder_dict[module_type]
         self.input_port_names = []
         self.output_port_names = []
         self.is_first = False
@@ -109,7 +111,8 @@ class MemTypeInfoByKey(object):
     def __init__(self, memList):        
         # Input: list of all memory objects of a given key type
         assert(len(memList) > 0)
-        self.mtype_short = memList[0].mtype_short() 
+        self.mtype_short = memList[0].mtype_short()
+        self.mtype_long = memList[0].mtype
         self.bitwidth   = memList[0].bitwidth
         self.bxbitwidth = memList[0].bxbitwidth
         self.is_binned  = memList[0].is_binned

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -90,9 +90,8 @@ def writeTBMemoryStimulusProcess(initial_proc):
     string_mem += "    variable v_line : line; -- Line for debug\n"
     string_mem += "  begin\n\n"
     string_mem += "    if START_FIRST_WRITE = '1' then\n"
-    string_mem += "      if rising_edge(CLK) then"
+    string_mem += "      if rising_edge(CLK) then\n"
     string_mem += "        if (CLK_COUNT < MAX_ENTRIES) then\n"
-    string_mem += "          CLK_COUNT := CLK_COUNT + 1;\n"
     string_mem += "          CLK_COUNT := CLK_COUNT + 1;\n"
     string_mem += "        else\n"
     string_mem += "          CLK_COUNT := 1;\n"
@@ -534,12 +533,12 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
     string_ctrl_signals += "  -- ### UUT signals ###\n"
     string_ctrl_signals += "  signal clk".ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += "  signal reset".ljust(str_len)+": std_logic := '1';\n"
+    string_ctrl_signals += ("  signal "+initial_proc+"_start").ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += ("  signal "+initial_proc+"_idle").ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += ("  signal "+initial_proc+"_ready").ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += ("  signal "+initial_proc+"_bx_in").ljust(str_len)+": std_logic_vector(2 downto 0) := (others => '1');\n"
     # Extra output ports if debug info must be sent to test-bench.
     for mid_proc in notfinal_procs:
-        string_ctrl_signals += ("  signal "+mid_proc+"_start").ljust(str_len)+": std_logic := '0';\n"
         string_ctrl_signals += ("  signal "+mid_proc+"_bx_out").ljust(str_len)+": std_logic_vector(2 downto 0) := (others => '1');\n"
         string_ctrl_signals += ("  signal "+mid_proc+"_bx_out_vld").ljust(str_len)+": std_logic := '0';\n"
         string_ctrl_signals += ("  signal "+mid_proc+"_done").ljust(str_len)+": std_logic := '0';\n"
@@ -656,12 +655,13 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
 
     return string_fwblock_inst
 
-def writeTBMemoryWriteInstance(mtypeB, proc, bxbitwidth, is_binned):
+def writeTBMemoryWriteInstance(mtypeB, proc, proc_up, bxbitwidth, is_binned):
     """
     # Writes the loop that writes the output from the memories to text files
     # Inputs:
     #   mtypeB:     the name of the memory type, including the number of bits (e.g. TPROJ_58)
     #   proc:       the processing module that writes to this memory.
+    #   proc_up:    the previous processing module (upstream). If proc is the initial module, then this is an empty string
     #   bxbitwidth: number of bits for the bunch-crossings. I.e. one page per bx.
     #   is_binned:  if the memory is binned or not.
     """
@@ -681,7 +681,7 @@ def writeTBMemoryWriteInstance(mtypeB, proc, bxbitwidth, is_binned):
     string_mem += "        ADDR".ljust(str_len)+"=> "+mtypeB+"_mem_AV_writeaddr(var),\n"
     string_mem += "        DATA".ljust(str_len)+"=> "+mtypeB+"_mem_AV_din(var),\n"
     string_mem += "        WRITE_EN".ljust(str_len)+"=> "+mtypeB+"_mem_A_wea(var),\n"
-    string_mem += "        START".ljust(str_len)+"=> "+proc+"_START,\n"
+    string_mem += "        START".ljust(str_len)+"=> "+(proc+"_START,\n" if not proc_up else proc_up+"_DONE,\n")
     string_mem += "        DONE".ljust(str_len)+"=> "+proc+"_DONE\n"
     string_mem += "      );\n"
     string_mem += "    end generate "+mtypeB+"_loop;\n\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -729,15 +729,18 @@ def writeTBMemoryWriteRAMInstance(mtypeB, proc, bxbitwidth, is_binned):
     #   is_binned:  if the memory is binned or not.
     """
     str_len = 16 # length of string for formatting purposes
+    string_mem = ""
 
-    string_mem = "  "+mtypeB+"_loop : for var in enum_"+mtypeB+" generate\n"
+    # FIX ME change number of bins from default 8 to 16 for VMSME Disk memories
+    string_mem += "  -- FIX ME change number of bins from default 8 to 16 for VMSME Disk memories!!!\n" if "VMSME" in mtypeB else ""
+
+    string_mem += "  "+mtypeB+"_loop : for var in enum_"+mtypeB+" generate\n"
     string_mem += "  begin\n"
     string_mem += "    write"+mtypeB+" : entity work.FileWriterFromRAM" + ("Binned\n" if is_binned else "\n")
     string_mem += "    generic map (\n"
     string_mem += "      FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mtypeB+"&memory_enum_to_string(var)&outputFileNameEnding,\n"
     string_mem += "      RAM_WIDTH".ljust(str_len)+"=> " + mtypeB.split("_")[1] + ",\n"
     string_mem += "      NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
-    string_mem += "      NUM_BINS".ljust(str_len)+"=> " + str(8) + "\n" if "VMSME" in mtypeB else ""     # FIX ME change number of bins for ME DISK?! from 8 to 16
     string_mem += "    )\n"
     string_mem += "    port map (\n"
     string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -614,7 +614,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     """
     str_len = 35 # length of string for formatting purposes
 
-    string_fwblock_inst =  "  sectorProcFull : if INST_TOP_TF = 1 generate\n" if notfinal_procs else "  sectorProc : if INST_TOP_TF = 0 generate\n"
+    string_fwblock_inst =  "  sectorProcFull : if INST_TOP_TF = 1 generate\n" if notfinal_procs or final_proc == initial_proc else "  sectorProc : if INST_TOP_TF = 0 generate\n"
     string_fwblock_inst += "  begin\n"
     string_fwblock_inst += "    uut : entity work." + topfunc + "\n"
     string_fwblock_inst += "      port map(\n"
@@ -672,7 +672,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     string_fwblock_inst += string_output[:-2]+"\n" # Remove the last comma
     
     string_fwblock_inst += "      );\n"
-    string_fwblock_inst += "  end generate sectorProcFull;\n\n" if notfinal_procs else "  end generate sectorProc;\n\n"
+    string_fwblock_inst += "  end generate sectorProcFull;\n\n" if notfinal_procs or final_proc == initial_proc else "  end generate sectorProc;\n\n"
 
     return string_fwblock_inst
 

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -241,7 +241,8 @@ def writeFWBlockInstantiation(topfunc, memDict, memInfoDict, initial_proc, final
 
     # Instantiate both the "normal" and the "Full"
     topfunc = topfunc[:-4] if topfunc[-4:] == "Full" else topfunc
-    string_instantiaion += writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc)
+    if initial_proc not in final_proc: # For a single module the normal and the full are the same
+        string_instantiaion += writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc)
     string_instantiaion += writeFWBlockInstance(topfunc+"Full", memDict, memInfoDict, initial_proc, final_proc, notfinal_procs)
     return string_instantiaion
 
@@ -259,7 +260,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
     for mtypeB in memDict:
         memInfo = memInfoDict[mtypeB]
         proc = memInfo.upstream_mtype_short # Processing module that writes to mtypeB
-        up_proc = notfinal_procs[notfinal_procs.index(proc)-1] if proc != notfinal_procs[0] and proc in notfinal_procs else "" # The previous processing module
+        up_proc = notfinal_procs[notfinal_procs.index(proc)-1] if notfinal_procs and proc != notfinal_procs[0] and proc in notfinal_procs else "" # The previous processing module
 
         if memInfo.is_final:
             string_final += writeTBMemoryWriteRAMInstance(mtypeB, proc, memInfo.bxbitwidth, memInfo.is_binned)

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -214,8 +214,12 @@ def writeTBMemoryReads(memDict, memInfoDict, initial_proc):
 
             if first_mem: # Write start signal for the first memory in the chain
                 string_read += "  -- As all " + memInfo.mtype_short + " signals start together, take first one, to determine when\n"
-                string_read += "  -- first event starts being written to first memory in chain.\n"
-                string_read += "  START_FIRST_WRITE <= START_" + memInfo.mtype_short + "(enum_" + mtypeB + "'val(0));\n\n" 
+                if "DL" in memInfo.mtype_short: 
+                    string_read += "  -- first event starts being read from the first link in the chain.\n"
+                    string_read += "  START_FIRST_LINK <= START_" + memInfo.mtype_short + "(enum_" + mtypeB + "'val(0));\n\n"
+                else:
+                    string_read += "  -- first event starts being written to first memory in chain.\n"
+                    string_read += "  START_FIRST_WRITE <= START_" + memInfo.mtype_short + "(enum_" + mtypeB + "'val(0));\n\n" 
                 found_first_mem = True
 
     # string_read += "\n"
@@ -258,7 +262,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
         up_proc = notfinal_procs[notfinal_procs.index(proc)-1] if proc != notfinal_procs[0] and proc in notfinal_procs else "" # The previous processing module
 
         if memInfo.is_final:
-            string_final += writeTBMemoryWriteRAMInstance(mtypeB, proc, memInfo.bxbitwidth)
+            string_final += writeTBMemoryWriteRAMInstance(mtypeB, proc, memInfo.bxbitwidth, memInfo.is_binned)
         elif not memInfo.is_initial: # intermediate memories
             string_intermediate += writeTBMemoryWriteInstance(mtypeB, proc, up_proc, memInfo.bxbitwidth, memInfo.is_binned)
 

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -209,10 +209,10 @@ def writeTBMemoryReads(memDict, memInfoDict, initial_proc):
         memInfo = memInfoDict[mtypeB]
 
         if memInfo.is_initial:
-            first_mem = True if initial_proc in memInfo.downstream_mtype_short else False # first memory of the chain
+            first_mem = True if initial_proc in memInfo.downstream_mtype_short and not found_first_mem else False # first memory of the chain
             string_read += writeTBMemoryReadInstance(mtypeB, memInfo.bxbitwidth, first_mem, memInfo.is_binned)
 
-            if first_mem and not found_first_mem: # Write start signal for the first memory in the chain
+            if first_mem: # Write start signal for the first memory in the chain
                 string_read += "  -- As all " + memInfo.mtype_short + " signals start together, take first one, to determine when\n"
                 string_read += "  -- first event starts being written to first memory in chain.\n"
                 string_read += "  START_FIRST_WRITE <= START_" + memInfo.mtype_short + "(enum_" + mtypeB + "'val(0));\n\n" 


### PR DESCRIPTION
Added implementation for generating testbenches. It works for the "standard" IRVMR, TETC, PRMEMC chains as well as a single ME. Examples of the testbenches can be seen here: https://github.com/meisonlikesicecream/firmware-hls/tree/me_vhdl_tb/IntegrationTests

I've tried it for the summer chain as well. It creates the tb, but I get errors when trying to run the simulation in Vivado. Did not look further into this.

Known weaknesses: it doesn't use 16 bins for VMSME in the disk. I.e. it uses the default 8 bins.