### PR TITLE
Fix to FIFOs in test-bench

### DIFF
--- a/TF_tb_constants.vhd.bodge
+++ b/TF_tb_constants.vhd.bodge
@@ -1,0 +1,5 @@
+  -- A bodge for TrackBuilder to write TF_464 concatenated track+stub data.
+  -- (Needed to compare with emData/).
+  constant FILE_OUT_TF_464      : string := dataOutDir&"TF_";
+  -- Empty field in the output from FT_L1L2 corresponding to disk matches
+  constant emptyDiskStub : std_logic_vector(48 downto 0) := (others => '0');

--- a/TF_tb_writer.vhd.bodge
+++ b/TF_tb_writer.vhd.bodge
@@ -1,0 +1,19 @@
+  -- A bodge for TrackBuilder to write TF_464 concatenated track+stub data.
+  -- (Needed to compare with emData/).
+  TF_464_loop : for var in enum_TW_84 generate
+  begin
+    writeTF_464 : entity work.FileWriterFIFO
+    generic map (
+      FILE_NAME  => FILE_OUT_TF_464&memory_enum_to_string(var)&outputFileNameEnding,
+      FIFO_WIDTH  => 464
+    )
+    port map (
+      CLK => CLK,
+      DONE => FT_DONE,
+      WRITE_EN => TW_84_stream_A_write(var),
+      FULL_NEG => TW_84_stream_A_full_neg(var),
+      DATA => TW_84_stream_AV_din(var)&BW_46_stream_AV_din(L1L2_L3)&BW_46_stream_AV_din(L1L2_L4)&BW_46_stream_AV_din
+(L1L2_L5)&BW_46_stream_AV_din(L1L2_L6)&emptyDiskStub&emptyDiskStub&emptyDiskStub&emptyDiskStub
+    );
+  end generate TF_464_loop;
+

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -88,8 +88,12 @@ class MemModule(Node):
         self.bxbitwidth = 0
         self.is_binned = False
         self.has_numEntries_out = True # True if has numEntries out port.
+
     def keyName(self): # All mems with same keyName made in same VHDL "generate" loop.
         return self.mtype_short()+"_"+str(self.bitwidth)
+    def isFIFO(self): # Is FIFO rather than BRAM memory
+        mts = self.mtype_short()
+        return (mts == "DL" or mts == "TW" or mts == "BW" or mts == "DW") 
     def __lt__(self, other) : # py3 needs this explicitly for ordering
         return self.inst < other.inst ### lexical sort on instance name
 
@@ -117,6 +121,7 @@ class MemTypeInfoByKey(object):
         self.bxbitwidth = memList[0].bxbitwidth
         self.is_binned  = memList[0].is_binned
         self.has_numEntries_out = memList[0].has_numEntries_out
+        self.isFIFO     = memList[0].isFIFO()
         # At least one memory of this type is initial.
         self.is_initial = any(m.is_initial for m in memList)
         # All memories of this type is final.

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1019,9 +1019,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                         #  no more than two dimensions
                         argname_is_2d_array = (tmp_argname.find('][') != -1) # Check if two-dimensional array
 
-                        # BarrelWords and DiskWords are treated differently
-                        # because they are currently streams
-                        if "BW" in memory.inst or "DW" in memory.inst:
+                        # FIFO (streams) such as BarrelWords & DiskWords are treated differently
+                        if memory.isFIFO():
                             argname_is_2d_array = False
 
                         tmp_argname = tmp_argname.split('[')[0] # Remove "[...]"
@@ -1066,7 +1065,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                             string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)
 
                     if portname.replace("outer","").find("out") != -1:
-                        if "TW" in memory.inst or "BW" in memory.inst or "DW" in memory.inst:
+                        if memory.isFIFO():
                             string_mem_ports += writeProcTrackStreamLHSPorts(tmp_argname,memory)
                         else:
                             string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)


### PR DESCRIPTION
Two fixes to the VHDL test-bench:

1) The signals for the FIFO interface were buggy, being those of a BRAM. Now fixed.
2) The concatenated track+stub output from the TrackBuilder, needed to compare with the emData/ file has been added.

After this is merged, the ir_phibinword_update branch will be rebased on top of it.

N.B. To be consistent with these changes, one change is required in the HLS repo: FileWriterFIFO.vhd must be edited to delete its (unnecesary) dependence on the START signal.