### PR TITLE
Fixed HW problems with START signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ https://github.com/cms-L1TK/firmware-hls in directory emData/ .
   1) Checkout the project generation scripts: `git clone git@github.com:cms-L1TK/project_generation_scripts.git`
   1) Checkout L1Trk HLS code: `git clone https://github.com/cms-tracklet/firmware-hls`
   1) Download the wiring files: `cd firmware-hls/emData/ ; ./download.sh -t; cd ../..`
-  1) Copy the wiring files to the project generation area: `cd firmware-hls/; cp ../firmware-hls/emData/LUTs/*.dat .`
+  1) Copy the wiring files to the project generation area: `cd project_generation_scripts/; cp ../firmware-hls/emData/LUTs/*.dat .`
   1) Ensure ROOT is in your PATH.
   1) Make top-level VHDL - example for PR-ME-MC chain: 
 ```
@@ -47,8 +47,9 @@ Example for IR-VMR chain:
 ```
 ./generator_hdl.py --uut VMR_L2PHIA -u 1 -d 0
 ```
-Example for "reduced" IR-VMR-TE-TC-PR-ME-MC-TB chain
+Example for "reduced" IR-VMR-TE-TC-PR-ME-MC-TB summer chain
 ```
+./makeReducedConfig.py
 ./generator_hdl.py --mut IR -u 0 -d 7 -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat
 ```
 *dirHLS* is the location of the HLS code, which defaults to "../firmware-hls".
@@ -91,7 +92,7 @@ Example for "reduced" IR-VMR-TE-TC-PR-ME-MC-TB chain
 
 ### makeReducedConfig.py
 
-This script takes an input wires.dat, modules.dat, and memories.dat file, and allows you to make a reduced configuration centered around one module (currently explicitly set to be one TC). The script takes the phi sector of the TC, and chooses phi sectors for the layers that line up with it, then recursively searches for TC inputs and outputs within those phi regions. It outputs a new set of wires, modules, and memories files including only these files.
+This script takes an input wires.dat, modules.dat, and memories.dat file, and allows you to make a reduced summer chain configuration centered around one module (currently explicitly set to be one TC). The script takes the phi sector of the TC, and chooses phi sectors for the layers that line up with it, then recursively searches for TC inputs and outputs within those phi regions. It outputs a new set of wires, modules, and memories files including only these files.
 
 By default the script will run starting with *TC_L1L2F*, and produced files called *reduced_wires.dat*, etc., but it can be modified with these options:
   

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -834,7 +834,13 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False):
         int_ctrl_wire += "  signal "+mtype+"_bx_out_vld : std_logic;\n"
     int_ctrl_wire += "  signal "+mtype_down+"_start : std_logic := '0';\n"
 
-    int_ctrl_func = "  "+mtype_down+"_start <= '1' when "+mtype+"_done = '1';\n\n"
+    int_ctrl_func =  "  LATCH_"+mtype+": entity work.CreateStartSignal\n"
+    int_ctrl_func += "    port map (\n"
+    int_ctrl_func += "      clk   => clk,\n"
+    int_ctrl_func += "      reset => reset,\n"
+    int_ctrl_func += "      done  => "+mtype+"_done,\n"
+    int_ctrl_func += "      start => "+mtype_down+"_start\n"
+    int_ctrl_func += "  );\n\n"
 
     return int_ctrl_wire,int_ctrl_func
 
@@ -924,11 +930,11 @@ def writeLUTParameters(argname, lut):
     if "in" in argname:
         width = 1
         depth = 8
-        parameterlist += "      lut_file  => "+"getDirEMDATA & \"LUTs/"+lut.inst+"_stubptinnercut.tab\",\n"
+        parameterlist += "      lut_file  => "+"getDirSCRIPT & \"LUTs/"+lut.inst+"_stubptinnercut.tab\",\n"
     elif "out" in argname:
         width = 1
         depth = 8
-        parameterlist += "      lut_file  => "+"getDirEMDATA & \"LUTs/"+lut.inst+"_stubptoutercut.tab\",\n"
+        parameterlist += "      lut_file  => "+"getDirSCRIPT & \"LUTs/"+lut.inst+"_stubptoutercut.tab\",\n"
     parameterlist += "      lut_width => "+str(width)+",\n"
     parameterlist += "      lut_depth => "+str(2**depth)+"\n"
     


### PR DESCRIPTION
Fixes the problems seen in HW with way START signals are produced from DONE signals of previous module in chain.

N.B. This relies on new utility common/hdl/CreateStartSignal.vhd in  https://github.com/cms-L1TK/firmware-hls/pull/216