### PR TITLE
Update default MemPrints directory and FullMatch memory port names

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -710,28 +710,6 @@ def matchArgPortNames_MC(argname, portname, memoryname):
         print("matchArgPortNames_MC: Unknown argument name", argname)
         return False
 
-# Temporary bodge to get the correct argname index for the fullmatch memories
-def decodeSeedIndex_MC(memoryname):
-    if 'L1L2' in memoryname:
-        return 0
-    elif 'L2L3' in memoryname:
-        return 1
-    elif 'L3L4' in memoryname:
-        return 2
-    elif 'L5L6' in memoryname:
-        return 3
-    elif 'D1D2' in memoryname:
-        return 4
-    elif 'D3D4' in memoryname:
-        return 5
-    elif 'L1D1' in memoryname:
-        return 6
-    elif 'L2D1' in memoryname:
-        return 7
-    else:
-        print("decodeSeedIndex_MC: Unknown memory name", memoryname)
-        return False
-
 ################################
 # FitTrack
 ################################
@@ -1038,10 +1016,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                             else:
                                 array_dict[tmp_argname] = 0
                             # Add array index to the name as HLS implements one port for each array element
-                            # Temporary bodge to account for encoded index in fullmatch and projection memories
-                            if tmp_argname == 'fullmatch':
-                                tmp_argname += "_" + str(decodeSeedIndex_MC(memory.inst))
-                            elif tmp_argname == 'projout_barrel_ps' or tmp_argname == 'projout_barrel_2s' or tmp_argname == 'projout_disk':
+                            # Temporary bodge to account for encoded index in projection memories
+                            if tmp_argname == 'projout_barrel_ps' or tmp_argname == 'projout_barrel_2s' or tmp_argname == 'projout_disk':
                                 tmp_argname += "_" + str(decodeSeedIndex_TC(memory.inst))
                             else:
                                 tmp_argname += "_" + str(array_dict[tmp_argname])

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -504,14 +504,14 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
                 mem_delay = procs.index(memInfo.downstream_mtype_short) # The delay in number of bx. The initial process of the chain will have 0 delay, the second have 1 bx delay etc.
 
                 string_constants += ("  constant " + memInfo.mtype_short + "_DELAY").ljust(str_len) + ": integer := " + str(mem_delay) + ";          --! Number of BX delays\n"
-                string_input_tmp += ("  constant FILE_IN_" + memInfo.mtype_short).ljust(str_len) + ": string := memPrintDir&\"" + mem_dir + "/" + mem_file_start + "_" + memInfo.mtype_short + "_\";\n"
+                string_input_tmp += ("  constant FILE_IN_" + memInfo.mtype_short).ljust(str_len) + ": string := memPrintsDir&\"" + mem_dir + "/" + mem_file_start + "_" + memInfo.mtype_short + "_\";\n"
                 string_debug_tmp += ("  constant FILE_OUT_" + memInfo.mtype_short + "_debug").ljust(str_len) + ": string := dataOutDir&\"" + memInfo.mtype_short + "_\";\n"
         else:
             string_output_tmp += ("  constant FILE_OUT_" + mtypeB).ljust(str_len) + ": string := dataOutDir&\"" + memInfo.mtype_short + "_\";\n"
     
     string_constants += "\n  -- Paths of data files specified relative to Vivado project's xsim directory.\n"
     string_constants += "  -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/\n"
-    string_constants += "  constant memPrintDir".ljust(str_len) + ": string := \"" + emData_dir + "\";\n"
+    string_constants += "  constant memPrintsDir".ljust(str_len) + ": string := \"" + emData_dir + "\";\n"
     string_constants += "  constant dataOutDir".ljust(str_len) + ": string := \"../../../../../dataOut/\";\n\n"
 
     string_constants += string_input_tmp

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -89,7 +89,7 @@ def writeTBMemoryStimulusProcess(initial_proc):
     string_mem += "    variable EVENT_COUNT : integer := -1;\n"
     string_mem += "    variable v_line : line; -- Line for debug\n"
     string_mem += "  begin\n\n"
-    string_mem += "    if START_FIRST_" + ("WRITE" if "IR" not in initial_proc else "LINK") + "= '1' then\n"
+    string_mem += "    if START_FIRST_" + ("WRITE" if "IR" not in initial_proc else "LINK") + " = '1' then\n"
     string_mem += "      if rising_edge(CLK) then\n"
     string_mem += "        if (CLK_COUNT < MAX_ENTRIES) then\n"
     string_mem += "          CLK_COUNT := CLK_COUNT + 1;\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -504,14 +504,14 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
                 mem_delay = procs.index(memInfo.downstream_mtype_short) # The delay in number of bx. The initial process of the chain will have 0 delay, the second have 1 bx delay etc.
 
                 string_constants += ("  constant " + memInfo.mtype_short + "_DELAY").ljust(str_len) + ": integer := " + str(mem_delay) + ";          --! Number of BX delays\n"
-                string_input_tmp += ("  constant FILE_IN_" + memInfo.mtype_short).ljust(str_len) + ": string := emDataDir&\"" + mem_dir + "/" + mem_file_start + "_" + memInfo.mtype_short + "_\";\n"
+                string_input_tmp += ("  constant FILE_IN_" + memInfo.mtype_short).ljust(str_len) + ": string := memPrintDir&\"" + mem_dir + "/" + mem_file_start + "_" + memInfo.mtype_short + "_\";\n"
                 string_debug_tmp += ("  constant FILE_OUT_" + memInfo.mtype_short + "_debug").ljust(str_len) + ": string := dataOutDir&\"" + memInfo.mtype_short + "_\";\n"
         else:
             string_output_tmp += ("  constant FILE_OUT_" + mtypeB).ljust(str_len) + ": string := dataOutDir&\"" + memInfo.mtype_short + "_\";\n"
     
     string_constants += "\n  -- Paths of data files specified relative to Vivado project's xsim directory.\n"
     string_constants += "  -- e.g. IntegrationTests/PRMEMC/script/Work/Work.sim/sim_1/behav/xsim/\n"
-    string_constants += "  constant emDataDir".ljust(str_len) + ": string := \"" + emData_dir + "\";\n"
+    string_constants += "  constant memPrintDir".ljust(str_len) + ": string := \"" + emData_dir + "\";\n"
     string_constants += "  constant dataOutDir".ljust(str_len) + ": string := \"../../../../../dataOut/\";\n\n"
 
     string_constants += string_input_tmp

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -294,7 +294,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
 
     return string_write
 
-def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memprint_dir, sector="04"):
+def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memPrintsDir, sector="04"):
     """
     # Inputs:
     #   tbfunc:       name of the testbench
@@ -305,7 +305,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memprint
     #   memDict:      dictionary of memories organised by type 
     #                 & no. of bits (TPROJ_58 etc.)
     #   memInfoDict:  dictionary of info (MemTypeInfoByKey) about each memory type.
-    #   memprint_dir:   directory where data for input memories is stored
+    #   memPrintsDir:   directory where data for input memories is stored
     #   sector:       which sector nonant the emData is taken from
     """
 
@@ -325,7 +325,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memprint
     string_header += writeTBPreamble()
     string_header += writeTBOpener(tbfunc)
 
-    string_constants = writeTBConstants(memDict, memInfoDict, notfinal_procs+[final_proc], memprint_dir, sector)
+    string_constants = writeTBConstants(memDict, memInfoDict, notfinal_procs+[final_proc], memPrintsDir, sector)
     # A bodge for TrackBuilder to write TF_464 concatenated track+stub data.
     # (Needed to compare with emData/).
     if 'TW_84' in memInfoDict.keys():
@@ -358,7 +358,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memprint
 ########################################
 # Tcl
 ########################################
-def writeTcl(projname, topfunc, memprint_dir):
+def writeTcl(projname, topfunc, memPrintsDir):
     string_tcl = "Not yet implemented!\n"
     return string_tcl
 
@@ -428,7 +428,7 @@ if __name__ == "__main__":
     parser.add_argument('-x', '--extraports', action='store_true', 
                         help="Add debug ports corresponding to all BRAM inputs")
 
-    parser.add_argument('--memprint_dir', type=str, default="../../../../../MemPrints/",
+    parser.add_argument('--memprints_dir', type=str, default="../../../../../MemPrints/",
                         help="Directory where emulation printouts are stored")
     parser.add_argument('-ng','--no_graph', action='store_true',
                         help="Don't make TrackletProject.pdf, so ROOT not required")
@@ -543,11 +543,11 @@ if __name__ == "__main__":
     # Test bench
     tb_name = "tb_tf_top"
     string_testbench = writeTestBench(
-        tb_name, topfunc, process_list, memDict, memInfoDict, args.memprint_dir)
+        tb_name, topfunc, process_list, memDict, memInfoDict, args.memprints_dir)
                                       
     ###############
     # tcl
-    string_tcl = writeTcl(args.projname, topfunc, args.memprint_dir)
+    string_tcl = writeTcl(args.projname, topfunc, args.memprints_dir)
     
     # Write to disk
     fname_memUtil = "memUtil_pkg.vhd"
@@ -576,17 +576,17 @@ if __name__ == "__main__":
     ###############
     # Copy the necessary emulation memory printouts for test bench
     # make a local directory first
-#    if os.path.exists(args.memprint_dir):
+#    if os.path.exists(args.memprints_dir):
 #        print("Creating a directory:", args.emData_dir)
 #        subprocess.call(['mkdir','-p',args.emData_dir])
 #
 #        print("Start to copy emulation printouts locally")
 #        for filename in list_memprints:
 #            memdir = getMemPrintDirectory(filename)+'/'
-#            fullname = args.memprint_dir.rstrip('/')+'/'+memdir+filename
+#            fullname = args.memprints_dir.rstrip('/')+'/'+memdir+filename
 #            subprocess.call(['cp', fullname, args.emData_dir+'/.'])
 #        print("Done copying emulation printouts")
 #    else:
-#        print("Cannot find directory", args.memprint_dir)
+#        print("Cannot find directory", args.memprints_dir)
 #        print("No memory prinout files are copied.")
     

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -294,7 +294,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
 
     return string_write
 
-def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, emData_dir, sector="04"):
+def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memprint_dir, sector="04"):
     """
     # Inputs:
     #   tbfunc:       name of the testbench
@@ -305,7 +305,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, emData_d
     #   memDict:      dictionary of memories organised by type 
     #                 & no. of bits (TPROJ_58 etc.)
     #   memInfoDict:  dictionary of info (MemTypeInfoByKey) about each memory type.
-    #   emData_dir:   directory where data for input memories is stored
+    #   memprint_dir:   directory where data for input memories is stored
     #   sector:       which sector nonant the emData is taken from
     """
 
@@ -325,7 +325,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, emData_d
     string_header += writeTBPreamble()
     string_header += writeTBOpener(tbfunc)
 
-    string_constants = writeTBConstants(memDict, memInfoDict, notfinal_procs+[final_proc], emData_dir, sector)
+    string_constants = writeTBConstants(memDict, memInfoDict, notfinal_procs+[final_proc], memprint_dir, sector)
     # A bodge for TrackBuilder to write TF_464 concatenated track+stub data.
     # (Needed to compare with emData/).
     if 'TW_84' in memInfoDict.keys():
@@ -358,7 +358,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, emData_d
 ########################################
 # Tcl
 ########################################
-def writeTcl(projname, topfunc, emData_dir):
+def writeTcl(projname, topfunc, memprint_dir):
     string_tcl = "Not yet implemented!\n"
     return string_tcl
 
@@ -428,11 +428,8 @@ if __name__ == "__main__":
     parser.add_argument('-x', '--extraports', action='store_true', 
                         help="Add debug ports corresponding to all BRAM inputs")
 
-    parser.add_argument('--emData_dir', type=str, default="../../../../../../../../emData/MemPrints/",
+    parser.add_argument('--memprint_dir', type=str, default="../../../../../MemPrints/",
                         help="Directory where emulation printouts are stored")
-    parser.add_argument('--memprint_dir', type=str,
-                        default="../fpga_emulation_longVM/MemPrints/",
-                        help="Directory of emulation memory printouts")
     parser.add_argument('-ng','--no_graph', action='store_true',
                         help="Don't make TrackletProject.pdf, so ROOT not required")
     args = parser.parse_args()
@@ -546,11 +543,11 @@ if __name__ == "__main__":
     # Test bench
     tb_name = "tb_tf_top"
     string_testbench = writeTestBench(
-        tb_name, topfunc, process_list, memDict, memInfoDict, args.emData_dir)
+        tb_name, topfunc, process_list, memDict, memInfoDict, args.memprint_dir)
                                       
     ###############
     # tcl
-    string_tcl = writeTcl(args.projname, topfunc, args.emData_dir)
+    string_tcl = writeTcl(args.projname, topfunc, args.memprint_dir)
     
     # Write to disk
     fname_memUtil = "memUtil_pkg.vhd"


### PR DESCRIPTION
Updated the default MemPrints directory in the script as the firmware repo now uses symbolic links to the MemPrints/ folder.

Also found that the port names for the FullMatch memories written by the script were outdated, so I fixed that as well.