### PR TITLE
Changes for barrel-only config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Basic instructions to run the project generation for the Vivado HLS project with hourglass configuration
 
-**These scripts are currently consistent with the [reduced_config_pr branch of the firmware-hls repository](https://github.com/cms-L1TK/firmware-hls/tree/reduced_config_pr), which is in the process of being merged into the master branch.**
-
 ## Overview of code for producing wiring files.
 
 (More technical details about the internal operation of the scripts can be found at end of this document).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ Example for "reduced" IR-VMR-TE-TC-PR-ME-MC-TB summer chain
 ./makeReducedConfig.py
 ./generator_hdl.py --mut IR -u 0 -d 7 -w reduced_wires.dat -p reduced_processingmodules.dat -m reduced_memorymodules.dat
 ```
+Example for barrel-only IR-VMR-TE-TC-PR-ME-MC-TB chain
+```
+./makeBarrelConfig.py
+./generator_hdl.py --mut IR -u 0 -d 7 -w barrel_wires.dat -p barrel_processingmodules.dat -m barrel_memorymodules.dat
+```
 *dirHLS* is the location of the HLS code, which defaults to "../firmware-hls".
 
 (Script *generator_vhls.py* is abandoned attempt at using HLS for top-level).

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -287,9 +287,9 @@ class TrackletGraph(object):
     #  they share a single IP core).
 
         if proc.mtype == 'MatchEngine':
-            # Final number unimportant in typical name "ME_D5PHIC11" 
-            # (Can probably drop phi region too).
-            proc.IPname = proc.inst[:9]
+            # Final number and phi region unimportant in typical name,
+            # e.g., "ME_D5PHIC11"
+            proc.IPname = proc.inst[:5]
         elif proc.mtype == 'TrackletEngine':
             proc.IPname = proc.inst[:5]+proc.inst.split("_")[2][:2]
         else:

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -291,7 +291,14 @@ class TrackletGraph(object):
             # e.g., "ME_D5PHIC11"
             proc.IPname = proc.inst[:5]
         elif proc.mtype == 'TrackletEngine':
-            proc.IPname = proc.inst[:5]+proc.inst.split("_")[2][:2]
+            innerPS = ("_L1" in proc.inst and "_L2" in proc.inst) \
+                   or ("_L2" in proc.inst and "_L3" in proc.inst) \
+                   or ("_L3" in proc.inst and "_L4" in proc.inst)
+            outerPS = ("_L1" in proc.inst and "_L2" in proc.inst) \
+                   or ("_L2" in proc.inst and "_L3" in proc.inst)
+            proc.IPname = "TE_"
+            proc.IPname += "PS_" if innerPS else "2S_"
+            proc.IPname += "PS" if outerPS else "2S"
         else:
             # FIX: check for other processing modules steps.
             proc.IPname = proc.inst

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -975,10 +975,15 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             if first_of_type:
                 string_bx_out += writeProcBXPort(module.mtype_short(),False,False) # output bx
         elif "table" in argname: # For TE
+            innerPS = ("_L1" in module.inst and "_L2" in module.inst) \
+                   or ("_L2" in module.inst and "_L3" in module.inst) \
+                   or ("_L3" in module.inst and "_L4" in module.inst)
+            outerPS = ("_L1" in module.inst and "_L2" in module.inst) \
+                   or ("_L2" in module.inst and "_L3" in module.inst)
             string_ports = writeLUTPorts(argname, module)
-            string_parameters = writeLUTParameters(argname, module)
+            string_parameters = writeLUTParameters(argname, module, innerPS, outerPS)
             module_str += writeLUTCombination(module, argname, string_ports, string_parameters)
-            str_ctrl_wire += writeLUTWires(argname, module)
+            str_ctrl_wire += writeLUTWires(argname, module, innerPS, outerPS)
             string_mem_ports += writeLUTMemPorts(argname, module)
         else:
             # Given argument name, search for the matched port name in the mem lists

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -942,11 +942,6 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     argtypes,argnames,templpars = parseProcFunction(module.mtype,fname_def)
 
     ####
-    # Determine function template parameters
-    templpars_str = f_writeTemplatePars(module)
-    templpars_str = templpars_str.replace(",","_");
-
-    ####
     # Write ports
     memModuleList, portNameList = getListsOfGroupedMemories(module)
 
@@ -1095,8 +1090,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
 
     ####
     # Put ingredients togther
-    module_str += writeProcCombination(module, str_ctrl_func, 
-                                      templpars_str, string_ports)
+    module_str += writeProcCombination(module, str_ctrl_func, string_ports)
     return str_ctrl_wire,module_str
 
 ################################

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -453,6 +453,18 @@ def writeTemplatePars_TC(aTCModule):
             # stubpair memory instance name example: SP_L1PHIB8_L2PHIA7
             innerphilabel = sp_instance.split('_')[1][0:6]
             outerphilabel = sp_instance.split('_')[2][0:6]
+
+            # PHII-PHIL corresponds to AS memories PHIA-PHID
+            # (only used for L2L3 seed)
+            innerphilabel = innerphilabel.replace("PHII", "PHIA")
+            innerphilabel = innerphilabel.replace("PHIJ", "PHIB")
+            innerphilabel = innerphilabel.replace("PHIK", "PHIC")
+            innerphilabel = innerphilabel.replace("PHIL", "PHID")
+            outerphilabel = outerphilabel.replace("PHII", "PHIA")
+            outerphilabel = outerphilabel.replace("PHIJ", "PHIB")
+            outerphilabel = outerphilabel.replace("PHIK", "PHIC")
+            outerphilabel = outerphilabel.replace("PHIL", "PHID")
+
             assert(innerphilabel in PhiLabelASInner)
             innerindex = PhiLabelASInner.index(innerphilabel)
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -798,7 +798,7 @@ def writeTBMemoryWriteFIFOInstance(mtypeB, proc, bxbitwidth):
 
     return string_mem 
 
-def writeProcCombination(module, str_ctrl_func, templpars_str, str_ports):
+def writeProcCombination(module, str_ctrl_func, str_ports):
     """
     # Instantiation of processing module within top-level.
     # FIXME needs fixing to include template parameters for generic proc module writing

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -924,32 +924,32 @@ def writeLUTPorts(argname,lut):
 
     return string_lut_ports
 
-def writeLUTParameters(argname, lut):
+def writeLUTParameters(argname, lut, innerPS, outerPS):
     parameterlist = ""
     width = 0
     if "in" in argname:
         width = 1
-        depth = 8
+        depth = 8 if innerPS else 9
         parameterlist += "      lut_file  => "+"getDirSCRIPT & \"LUTs/"+lut.inst+"_stubptinnercut.tab\",\n"
     elif "out" in argname:
         width = 1
-        depth = 8
+        depth = 8 if outerPS else 9
         parameterlist += "      lut_file  => "+"getDirSCRIPT & \"LUTs/"+lut.inst+"_stubptoutercut.tab\",\n"
     parameterlist += "      lut_width => "+str(width)+",\n"
     parameterlist += "      lut_depth => "+str(2**depth)+"\n"
     
     return parameterlist
 
-def writeLUTWires(argname, lut):
+def writeLUTWires(argname, lut, innerPS, outerPS):
     wirelist = ""
     argname = argname.split("[")[0]
     depth = 0
     width = 0
     if "in" in argname:
-        depth = 8
+        depth = 8 if innerPS else 9
         width = 1
     elif "out" in argname:
-        depth = 8
+        depth = 8 if outerPS else 9
         width = 1
     wirelist += "  signal "+lut.inst+"_"+argname+"_addr       : "
     wirelist += "std_logic_vector("+str(depth-1)+" downto 0);\n"

--- a/makeBarrelConfig.py
+++ b/makeBarrelConfig.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+import sys
+
+if len(sys.argv) < 2:
+    print("Usage: " + sys.argv[0] + " WIRES_FILE")
+    sys.exit(1)
+
+wiresFileName = sys.argv[1]
+fin = open(wiresFileName)
+outputWires = []
+processingModules = []
+memoryModules = []
+dtcs = {}
+for line in fin:
+    splitLine = line.split()
+    assert(len(splitLine) == 4 or len(splitLine) == 5)
+
+    memName = splitLine[0]
+
+    inputModule = None
+    outputModule = None
+    if len(splitLine) == 5:
+        inputModule = splitLine[2].split(".")[0]
+        outputModule = splitLine[4].split(".")[0]
+    else:
+        if splitLine[-1] == "output=>":
+            inputModule = splitLine[2].split(".")[0]
+        else:
+            outputModule = splitLine[-1].split(".")[0]
+
+    dtc = None
+    if inputModule is not None and inputModule.startswith("IR_"):
+        assert(memName.startswith("IL_"))
+        dtc = inputModule[3:]
+        if dtc not in dtcs:
+            dtcs[dtc] = 0
+        else:
+            dtcs[dtc] += 1
+
+    if "_D" in line or "L1D1" in line or "L2D1" in line:
+        if dtc is not None:
+            dtcs[dtc] -= 1
+        continue
+
+    outputWires.append(line)
+    memoryModules.append(memName)
+    if inputModule is not None:
+        processingModules.append(inputModule)
+    if outputModule is not None:
+        processingModules.append(outputModule)
+
+fin.close()
+
+fout = open("barrel_wires.dat", "w")
+for line in outputWires:
+    output = True
+    for dtc in dtcs:
+        if dtcs[dtc] > 0:
+            continue
+        if dtc in line:
+            output = False
+            break
+    if not output:
+        continue
+    fout.write(line)
+fout.close()
+
+fout = open("barrel_processingmodules.dat", "w")
+for p in sorted(set(processingModules)):
+    output = True
+    for dtc in dtcs:
+        if dtcs[dtc] > 0:
+            continue
+        if dtc in p:
+            output = False
+            break
+    if not output:
+        continue
+    if p.startswith("IR_"):
+        fout.write("InputRouter: " + p + "\n")
+    elif p.startswith("VMR_"):
+        fout.write("VMRouter: " + p + "\n")
+    elif p.startswith("TE_"):
+        fout.write("TrackletEngine: " + p + "\n")
+    elif p.startswith("TC_"):
+        fout.write("TrackletCalculator: " + p + "\n")
+    elif p.startswith("PR_"):
+        fout.write("ProjectionRouter: " + p + "\n")
+    elif p.startswith("ME_"):
+        fout.write("MatchEngine: " + p + "\n")
+    elif p.startswith("MC_"):
+        fout.write("MatchCalculator: " + p + "\n")
+    elif p.startswith("FT_"):
+        fout.write("FitTrack: " + p + "\n")
+    elif p.startswith("PD"):
+        fout.write("PurgeDuplicate: " + p + "\n")
+fout.close()
+
+fout = open("barrel_memorymodules.dat", "w")
+for m in sorted(set(memoryModules)):
+    output = True
+    for dtc in dtcs:
+        if dtcs[dtc] > 0:
+            continue
+        if dtc in m:
+            output = False
+            break
+    if not output:
+        continue
+    if m.startswith("AP_"):
+        fout.write("AllProj: " + m + " [56]\n")
+    elif m.startswith("AS_"):
+        fout.write("AllStubs: " + m + " [42]\n")
+    elif m.startswith("CM_"):
+        fout.write("CandidateMatch: " + m + " [12]\n")
+    elif m.startswith("CT_"):
+        fout.write("CleanTrack: " + m + " [126]\n")
+    elif m.startswith("DL_"):
+        fout.write("DTCLink: " + m + " [36]\n")
+    elif m.startswith("FM_"):
+        fout.write("FullMatch: " + m + " [36]\n")
+    elif m.startswith("IL_"):
+        fout.write("InputLink: " + m + " [36]\n")
+    elif m.startswith("SP_"):
+        fout.write("StubPairs: " + m + " [12]\n")
+    elif m.startswith("TF_"):
+        fout.write("TrackFit: " + m + " [126]\n")
+    elif m.startswith("TPAR_"):
+        fout.write("TrackletParameters: " + m + " [56]\n")
+    elif m.startswith("TPROJ_"):
+        fout.write("TrackletProjections: " + m + " [54]\n")
+    elif m.startswith("VMPROJ_"):
+        fout.write("VMProjections: " + m + " [13]\n")
+    elif m.startswith("VMSME_"):
+        fout.write("VMStubsME: " + m + " [18]\n")
+    elif m.startswith("VMSTE_"):
+        fout.write("VMStubsTE: " + m + " [18]\n")
+fout.close()


### PR DESCRIPTION
This PR contains changes needed for the barrel-only config.

This includes a script, makeBarrelConfig.py, which generates the wires files for the barrel-only config, very much like makeReducedConfig.py generates wires files for the reduced config.

There are also three fixes in the existing scripts to accommodate the barrel-only config:
- The phi region is removed from the names of the ME IPs. This is because, e.g., ME_L3PHIA, ME_L3PHIB, ME_L3PHIC, etc. share a common IP.
- The seed stub types are used in the names of the TE IPs instead of the seed (e.g., TE_PS_PS instead of TE_L1L2). This is because the TEs for L1L2 and L2L3 share an IP.
- The width of the 2S lookup tables for the TEs is increased from 8 to 9 bits.