### PR TITLE
move TP LUTs into HLS top function, remove lut modules

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1202,12 +1202,6 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             module_str += writeLUTCombination(module, argname, string_ports, string_parameters)
             str_ctrl_wire += writeLUTWires(argname, module, innerPS, outerPS)
             string_mem_ports += writeLUTMemPorts(argname, module)
-        elif "lut" in argname: # For TP
-            string_ports = writeLUTPorts(argname, module)
-            string_parameters = writeLUTParameters(argname, module, False, False) #last two args are not used
-            module_str += writeLUTCombination(module, argname, string_ports, string_parameters)
-            str_ctrl_wire += writeLUTWires(argname, module, False, False) #last two args are not used
-            string_mem_ports += writeLUTMemPorts(argname, module)
         else:
             # Given argument name, search for the matched port name in the mem lists
             foundMatch = False

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -899,8 +899,6 @@ def writeLUTCombination(lut, argname, portlist, parameterlist):
     lut_str = ""
     if "TE_" in lut.inst:
         lut_str += "\n  "+lut.inst+"_"+argname+" : entity work.tf_lut"
-    else:
-        lut_str += "\n  "+lut.inst+"_"+argname+" : entity work.tf_lutdat"
     lut_str += "\n    generic map (\n"+parameterlist.rstrip(",\n")+"\n    )"
     lut_str += "\n    port map (\n"+portlist.rstrip(",\n")+"\n  );\n\n"
 
@@ -1094,14 +1092,6 @@ def writeLUTParameters(argname, lut, innerPS, outerPS):
         width = 1
         depth = 8 if outerPS else 9
         parameterlist += "      lut_file  => \"LUTs/"+lut.inst+"_stubptoutercut.tab\",\n"
-    elif "regionlut" in argname: #For TP
-        width = 8
-        depth = 11
-        parameterlist += "      lut_file  => \"LUTs/"+lut.inst+"_usereg.dat\",\n"
-    elif "lut" in argname: #For TP
-        width = 10
-        depth = 11
-        parameterlist += "      lut_file  => \"LUTs/"+lut.inst[:-1]+".dat\",\n" #remove the last character
     parameterlist += "      lut_width => "+str(width)+",\n"
     parameterlist += "      lut_depth => "+str(2**depth)+"\n"
     
@@ -1118,12 +1108,6 @@ def writeLUTWires(argname, lut, innerPS, outerPS):
     elif "out" in argname:
         depth = 8 if outerPS else 9
         width = 1
-    elif "regionlut" in argname: #For TP
-        width = 8
-        depth = 11
-    elif "lut" in argname: #For TP
-        width = 10
-        depth = 11
     wirelist += "  signal "+lut.inst+"_"+argname+"_addr       : "
     wirelist += "std_logic_vector("+str(depth-1)+" downto 0);\n"
     wirelist += "  signal "+lut.inst+"_"+argname+"_ce       : std_logic;\n"


### PR DESCRIPTION
PR for [firmware_hls #261](https://github.com/cms-L1TK/firmware-hls/pull/261), removes LUT modules in combined module chains and associated ports/wires.