### PR TITLE
add pipeline modules needed in full-barrel combined chain

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -585,12 +585,16 @@ class TrackletGraph(object):
         file_wires.close()
 
         # Remove processing modules if they do not have input/output memories
+
         for name, proc in p_dict.items():
             nInputs = len(proc.upstreams)
             nOutputs = len(proc.downstreams)
             
             if nInputs == 0 or nOutputs == 0:
-                del p_dict[name]
+                print("Error module:", name, "with nInputs =", nInputs, "nOutputs =", nOutputs)
+                exit(0)
+
+
         
     ########################################       
     # Accessors

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1125,7 +1125,7 @@ def parseProcFunction(proc_name, fname_def):
     return arg_types_list, arg_names_list, templ_pars_list
 
 def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
-                              f_matchArgPortNames, first_of_type, extraports):
+                              f_matchArgPortNames, first_of_type, extraports,delay):
     ####
     # function name
     assert(module.mtype in ['InputRouter', 'VMRouter', 'VMRouterCM', 'TrackletEngine', 'TrackletCalculator',
@@ -1142,7 +1142,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             if mem.bxbitwidth != 1: continue
             oneProcDownMem = mem
             break
-        ctrl_wire_inst,ctrl_func_inst = writeStartSwitchAndInternalBX(module,oneProcDownMem,extraports)
+        ctrl_wire_inst,ctrl_func_inst = writeStartSwitchAndInternalBX(module,oneProcDownMem,extraports,delay)
         str_ctrl_wire += ctrl_wire_inst
         str_ctrl_func += ctrl_func_inst
         
@@ -1316,71 +1316,71 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     return str_ctrl_wire,module_str
 
 ################################
-def writeModuleInstance(module, hls_src_dir, first_of_type, extraports):
+def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay):
     if module.mtype == 'InputRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_IR,
                                          matchArgPortNames_IR,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'VMRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMR,
                                          matchArgPortNames_VMR,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'VMRouterCM':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMRCM,
                                          matchArgPortNames_VMRCM,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'TrackletEngine':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TE,
                                          matchArgPortNames_TE,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'TrackletProcessor':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TP,
                                          matchArgPortNames_TP,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'TrackletCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TC,
                                          matchArgPortNames_TC,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'ProjectionRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_PR,
                                          matchArgPortNames_PR,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'MatchEngine':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_ME,
                                          matchArgPortNames_ME,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'MatchCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_MC,
                                          matchArgPortNames_MC,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'MatchProcessor':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_MP,
                                          matchArgPortNames_MP,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'FitTrack':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_FT,
                                          matchArgPortNames_FT,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'TrackBuilder':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TB,
                                          matchArgPortNames_TB,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     elif module.mtype == 'PurgeDuplicate':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_PD,
                                          matchArgPortNames_PD,
-                                         first_of_type, extraports)
+                                         first_of_type, extraports, delay)
     else:
         raise ValueError(module.mtype + " is unknown.")

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1183,14 +1183,14 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             for mem in module.upstreams:
                 if mem.bxbitwidth != 1: continue
                 if mem.is_initial:
-                    string_bx_in += writeProcBXPort(module.mtype_short(),True,True)
+                    string_bx_in += writeProcBXPort(module.mtype_short(),True,True,delay)
                     break
                 else:
-                    string_bx_in += writeProcBXPort(mem.upstreams[0].mtype_short(),True,False)
+                    string_bx_in += writeProcBXPort(mem.upstreams[0].mtype_short(),True,False,delay)
                     break
         elif argtype == "BXType&" or argtype == "BXType &": # Could change this in the HLS instead
             if first_of_type:
-                string_bx_out += writeProcBXPort(module.mtype_short(),False,False) # output bx
+                string_bx_out += writeProcBXPort(module.mtype_short(),False,False,delay) # output bx
         elif "table" in argname: # For TE
             innerPS = ("_L1" in module.inst and "_L2" in module.inst) \
                    or ("_L2" in module.inst and "_L3" in module.inst) \

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -350,6 +350,13 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
         sync_signal = memInfo.downstream_mtype_short+"_start"
 
     # Write wires
+    if True: #FIXME change this to take an argument flag
+        wirelist += "  signal "+mtypeB+"_mem_A_wea_delay          : "
+        wirelist += "t_arr_"+mtypeB+"_1b;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_writeaddr_delay   : "
+        wirelist += "t_arr_"+mtypeB+"_ADDR;\n"
+        wirelist += "  signal "+mtypeB+"_mem_AV_din_delay         : "
+        wirelist += "t_arr_"+mtypeB+"_DATA;\n"
     if (interface != -1 and not extraports) or (interface == 1 and extraports):
         wirelist += "  signal "+mtypeB+"_mem_A_wea          : "
         wirelist += "t_arr_"+mtypeB+"_1b;\n"
@@ -357,13 +364,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
         wirelist += "t_arr_"+mtypeB+"_ADDR;\n"
         wirelist += "  signal "+mtypeB+"_mem_AV_din         : "
         wirelist += "t_arr_"+mtypeB+"_DATA;\n"
-        if True: #FIXME change this to take an argument flag
-            wirelist += "  signal "+mtypeB+"_mem_A_wea_delay          : "
-            wirelist += "t_arr_"+mtypeB+"_1b;\n"
-            wirelist += "  signal "+mtypeB+"_mem_AV_writeaddr_delay   : "
-            wirelist += "t_arr_"+mtypeB+"_ADDR;\n"
-            wirelist += "  signal "+mtypeB+"_mem_AV_din_delay         : "
-            wirelist += "t_arr_"+mtypeB+"_DATA;\n"
     
     if interface != 1:
         if combined :
@@ -765,6 +765,7 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
             string_ctrl_signals += ("  signal "+mtypeB+"_mem_AV_din").ljust(str_len)+": "
             string_ctrl_signals += ("t_arr_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => (others => '0'));\n"
 
+
     if "DL" in first_mem:
         string_ctrl_signals += "\n  -- Indicates that reading of DL of first event has started.\n"
         string_ctrl_signals += "  signal START_FIRST_LINK : std_logic := '0';\n"
@@ -1039,7 +1040,10 @@ def writeProcBXPort(modName,isInput,isInitial):
     elif isInput and not isInitial:
         bx_str += "      bx_V          => "+modName+"_bx_out,\n"
     elif not isInput:
-        bx_str += "      bx_o_V        => "+modName+"_bx_out_0,\n"
+        if modName == "FT":
+            bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
+        else:
+            bx_str += "      bx_o_V        => "+modName+"_bx_out_0,\n"
         bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
     return bx_str
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -440,7 +440,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
     if memList[0].has_numEntries_out:
         if memList[0].is_binned:
             if combined:
-                portlist += "        mask_o    => "+mtypeB+"_mem_AAV_dout_mask(var),\n"
                 if "VMSTE" in mtypeB :
                     portlist += "        nent_o    => "+mtypeB+"_mem_AAAV_dout_nent(var),\n"
                 else:
@@ -1085,12 +1084,9 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
                     string_mem_ports += "      "+argname+"_nentries8b_v_address0        => "+mem.keyName()+"_mem_AV_addr_nentB("+mem.var()+"),\n"
                     string_mem_ports += "      "+argname+"_nentries8b_v_ce0             => "+mem.keyName()+"_mem_A_enb_nentB("+mem.var()+"),\n"
                 else:
+                    for i in range(0,2**mem.bxbitwidth): 
                         string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
                         string_mem_ports += mem.keyName()+"_mem_AAV_dout_nent("+mem.var()+")("+str(i)+"),\n"
-            else:
-                for i in range(0,2**mem.bxbitwidth):
-                    string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
-                    string_mem_ports += mem.keyName()+"_mem_AAV_dout_nent("+mem.var()+")("+str(i)+"),\n"
         else:
             for i in range(0,2**mem.bxbitwidth):
                 if mem.is_binned:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1080,6 +1080,12 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
     if combined and (mem.mtype == "VMStubsTEOuter" or mem.mtype == "VMStubsME"): #FIXME hack for combined modules
         string_mem_ports = ""
         nmem = 5
+        #FIXME special case for L2L3 seeding where we have 2 TE
+        if "VMSTE_L3" in mem.inst :
+            nmem = 2
+        #FIXME special case for L5L6 seeding where we have 3 TE
+        if "VMSTE_L6" in mem.inst :
+            nmem = 3
         if mem.mtype == "VMStubsME" :
             nmem = 4
         for instance in range(0,nmem):

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1085,9 +1085,12 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
                     string_mem_ports += "      "+argname+"_nentries8b_v_address0        => "+mem.keyName()+"_mem_AV_addr_nentB("+mem.var()+"),\n"
                     string_mem_ports += "      "+argname+"_nentries8b_v_ce0             => "+mem.keyName()+"_mem_A_enb_nentB("+mem.var()+"),\n"
                 else:
-                    for i in range(0,2**mem.bxbitwidth): 
                         string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
                         string_mem_ports += mem.keyName()+"_mem_AAV_dout_nent("+mem.var()+")("+str(i)+"),\n"
+            else:
+                for i in range(0,2**mem.bxbitwidth):
+                    string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
+                    string_mem_ports += mem.keyName()+"_mem_AAV_dout_nent("+mem.var()+")("+str(i)+"),\n"
         else:
             for i in range(0,2**mem.bxbitwidth):
                 if mem.is_binned:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -516,7 +516,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = True):
         if module == "TP_" :
             mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm5\n"
         elif module == "MP_" :
-            mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm4_new\n"
+            mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm4\n"
         else:
             mem_str += "    "+mtypeB+" : entity work.tf_mem_bin\n"
     else:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -440,6 +440,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
     if memList[0].has_numEntries_out:
         if memList[0].is_binned:
             if combined:
+                portlist += "        mask_o    => "+mtypeB+"_mem_AAV_dout_mask(var),\n"
                 if "VMSTE" in mtypeB :
                     portlist += "        nent_o    => "+mtypeB+"_mem_AAAV_dout_nent(var),\n"
                 else:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -997,12 +997,16 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False):
         int_ctrl_wire += "  signal "+mtype+"_bx_out : std_logic_vector(2 downto 0);\n"
         int_ctrl_wire += "  signal "+mtype+"_bx_out_vld : std_logic;\n"
     int_ctrl_wire += "  signal "+mtype_down+"_start : std_logic := '0';\n"
-
+    if True:#FIXME add delay flag
+        int_ctrl_wire += "  signal "+mtype+"_bx_out_0 : std_logic_vector(2 downto 0);\n"
     int_ctrl_func =  "  LATCH_"+mtype+": entity work.CreateStartSignal\n"
     int_ctrl_func += "    port map (\n"
     int_ctrl_func += "      clk   => clk,\n"
     int_ctrl_func += "      reset => reset,\n"
     int_ctrl_func += "      done  => "+mtype+"_done,\n"
+    if True:
+        int_ctrl_func += "      bx_out => "+mtype+"_bx_out_0,\n"
+        int_ctrl_func += "      bx => "+mtype+"_bx_out,\n"
     int_ctrl_func += "      start => "+mtype_down+"_start\n"
     int_ctrl_func += "  );\n\n"
 
@@ -1035,7 +1039,7 @@ def writeProcBXPort(modName,isInput,isInitial):
     elif isInput and not isInitial:
         bx_str += "      bx_V          => "+modName+"_bx_out,\n"
     elif not isInput:
-        bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
+        bx_str += "      bx_o_V        => "+modName+"_bx_out_0,\n"
         bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
     return bx_str
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1020,7 +1020,8 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False, delay = 0):
         int_ctrl_wire += "  signal "+mtype+"_bx_out_vld : std_logic;\n"
     int_ctrl_wire += "  signal "+mtype_down+"_start : std_logic := '0';\n"
     int_ctrl_func =  "  LATCH_"+mtype+": entity work.CreateStartSignal\n"
-    startsignal_parameter_list +="        DELAY           => " + str(delay*2) +",\n"
+    if delay > 0:
+      startsignal_parameter_list +="        DELAY           => " + str(delay*2) +",\n"
     int_ctrl_func += "      generic map (\n"+startsignal_parameter_list.rstrip(",\n")+"\n      )\n"
 
     int_ctrl_func += "    port map (\n"
@@ -1053,7 +1054,7 @@ def writeProcControlSignalPorts(module,first_of_type):
 
     return string_ctrl_ports
 
-def writeProcBXPort(modName,isInput,isInitial):
+def writeProcBXPort(modName,isInput,isInitial,delay):
     """
     # Processing module port assignment: BX ports
     """
@@ -1063,7 +1064,7 @@ def writeProcBXPort(modName,isInput,isInitial):
     elif isInput and not isInitial:
         bx_str += "      bx_V          => "+modName+"_bx_out,\n"
     elif not isInput:
-        if modName == "FT":
+        if modName == "FT" or delay==0:
             bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
             bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
         else:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -466,7 +466,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports):
         if module == "TP_" :
             mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm5\n"
         elif module == "MP_" :
-            mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm4\n"
+            mem_str += "    "+mtypeB+" : entity work.tf_mem_bin_cm4_new\n"
         else:
             mem_str += "    "+mtypeB+" : entity work.tf_mem_bin\n"
     else:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1042,9 +1042,10 @@ def writeProcBXPort(modName,isInput,isInitial):
     elif not isInput:
         if modName == "FT":
             bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
+            bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
         else:
             bx_str += "      bx_o_V        => "+modName+"_bx_out_0,\n"
-        bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
+            bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
     return bx_str
 
 def writeProcMemoryLHSPorts(argname,mem,combined=False):

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -31,7 +31,7 @@ import os, subprocess
 # Memories
 ########################################
 
-def writeMemoryModules(memDict, memInfoDict, extraports , delay = True):
+def writeMemoryModules(memDict, memInfoDict, extraports , delay):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -56,7 +56,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports , delay = True):
 ########################################
 # Processing modules
 ########################################
-def writeProcModules(proc_list, hls_src_dir, extraports):
+def writeProcModules(proc_list, hls_src_dir, extraports, delay):
     """
     # proc_list:   a list of processing modules
     # hls_src_dir: string pointing to the HLS directory, used to extract constants
@@ -73,10 +73,10 @@ def writeProcModules(proc_list, hls_src_dir, extraports):
 
     for aProcMod in proc_list:
         if not aProcMod.mtype in proc_type_list: # Is this aProcMod the first of its type
-            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports)
+            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports, delay)
             proc_type_list.append(aProcMod.mtype)
         else:
-            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, False, extraports)
+            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, False, extraports, delay)
         string_proc_wire += proc_wire_inst
         string_proc_func += proc_func_inst
         
@@ -85,7 +85,7 @@ def writeProcModules(proc_list, hls_src_dir, extraports):
 ########################################
 # Top function interface
 ########################################
-def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, streamIO=False, delay=True):
+def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, delay, streamIO=False):
     """
     # topmodule_name:  name of the top module
     # process_list:    list of all processing functions in the block (in this function, this list is
@@ -117,7 +117,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
     string_topmod_interface = writeTopModuleOpener(topmodule_name)
 
     # Write control signals
-    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_proc, notfinal_procs, delay = True)
+    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_proc, notfinal_procs, delay = delay)
     
     string_input_mems = ""
     string_output_mems = ""
@@ -150,7 +150,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
 ########################################
 # Top file
 ########################################
-def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports, delay=True):
+def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports, delay):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -173,11 +173,11 @@ def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraport
     # HLS source code directory
     source_dir = hls_dir.rstrip('/')+'/TrackletAlgorithm'
 
-    string_procWires, string_procModules = writeProcModules(process_list, source_dir, extraports)
+    string_procWires, string_procModules = writeProcModules(process_list, source_dir, extraports, delay)
 
     # Top function interface
     string_topmod_interface = writeTopModule_interface(topfunc, process_list,
-                                                       memDict, memInfoDict, extraports)
+                                                       memDict, memInfoDict, extraports, delay)
 
     string_src = ""
     string_src += writeTopPreamble()
@@ -431,8 +431,8 @@ if __name__ == "__main__":
                         help="Number of downstream processing steps to include")
     parser.add_argument('-x', '--extraports', action='store_true', 
                         help="Add debug ports corresponding to all BRAM inputs")
-    parser.add_argument('-de', '--delay', action='store_true', 
-                        help="Enables additional pipeline stages on writing to memory modules")
+    parser.add_argument('-de', '--delay', type=int, default=0,
+                        help="Number of pipeline stages in between processing and memory modules to include, setting 0 does not include pipeline modules")
 
     parser.add_argument('--memprints_dir', type=str, default="../../../../../MemPrints/",
                         help="Directory where emulation printouts are stored")

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -31,7 +31,7 @@ import os, subprocess
 # Memories
 ########################################
 
-def writeMemoryModules(memDict, memInfoDict, extraports):
+def writeMemoryModules(memDict, memInfoDict, extraports , delay = True):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -47,7 +47,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports):
         # FIFO memories are not instantiated in top-level (at end of chain?)
         if memInfo.isFIFO:
             continue
-        string_wires_inst, string_mem_inst = writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports)
+        string_wires_inst, string_mem_inst = writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = delay)
         string_wires += string_wires_inst
         string_mem += string_mem_inst
     
@@ -85,7 +85,7 @@ def writeProcModules(proc_list, hls_src_dir, extraports):
 ########################################
 # Top function interface
 ########################################
-def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, streamIO=False):
+def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, streamIO=False, delay=True):
     """
     # topmodule_name:  name of the top module
     # process_list:    list of all processing functions in the block (in this function, this list is
@@ -117,7 +117,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
     string_topmod_interface = writeTopModuleOpener(topmodule_name)
 
     # Write control signals
-    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_proc, notfinal_procs)
+    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_proc, notfinal_procs, delay = True)
     
     string_input_mems = ""
     string_output_mems = ""
@@ -150,7 +150,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
 ########################################
 # Top file
 ########################################
-def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports):
+def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports, delay=True):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -161,7 +161,7 @@ def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraport
     # Write memories
     string_memWires = ""
     string_memModules = ""
-    memWires_inst,memModules_inst = writeMemoryModules(memDict, memInfoDict, extraports)
+    memWires_inst,memModules_inst = writeMemoryModules(memDict, memInfoDict, extraports, delay)
     string_memWires   += memWires_inst
     string_memModules += memModules_inst
 
@@ -431,6 +431,8 @@ if __name__ == "__main__":
                         help="Number of downstream processing steps to include")
     parser.add_argument('-x', '--extraports', action='store_true', 
                         help="Add debug ports corresponding to all BRAM inputs")
+    parser.add_argument('-de', '--delay', action='store_true', 
+                        help="Enables additional pipeline stages on writing to memory modules")
 
     parser.add_argument('--memprints_dir', type=str, default="../../../../../MemPrints/",
                         help="Directory where emulation printouts are stored")
@@ -541,7 +543,7 @@ if __name__ == "__main__":
     ###############
     #  Top File
     string_topfile = writeTopFile(topfunc, process_list,
-                                  memDict, memInfoDict, args.hls_dir, args.extraports)
+                                  memDict, memInfoDict, args.hls_dir, args.extraports, args.delay)
 
     ###############
     # Test bench


### PR DESCRIPTION
PR adds the necessary code to sectorprocessor that manages the new pipeline modules in between processing and memory modules in the latest version of combined module chains. These pipeline modules are turned on through an optional flag.

related to firmware hls : [281](https://github.com/cms-L1TK/firmware-hls/pull/281)

