### PR TITLE
SW/FW synchronization

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -214,7 +214,7 @@ class TrackletGraph(object):
         elif mem.mtype == "StubPairs":
             mem.bitwidth = 14
         elif mem.mtype == "TrackletParameters":
-            mem.bitwidth = 70
+            mem.bitwidth = 73
         elif mem.mtype == "TrackletProjections" or mem.mtype == "AllProj":
             if barrelPS>-1: mem.bitwidth = 60
             if barrel2S>-1: mem.bitwidth = 58
@@ -231,7 +231,7 @@ class TrackletGraph(object):
             if barrelPS>-1 or barrel2S>-1: mem.bitwidth = 52
             if disk>-1: mem.bitwidth = 55
         elif mem.mtype == "TrackWord":
-            mem.bitwidth = 98
+            mem.bitwidth = 104
         elif mem.mtype == "BarrelStubWord":
             mem.bitwidth = 46
         elif mem.mtype == "DiskStubWord":

--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -585,13 +585,17 @@ class TrackletGraph(object):
 
         # Remove processing modules if they do not have input/output memories
 
+        errorMsg = ""
         for name, proc in p_dict.items():
             nInputs = len(proc.upstreams)
             nOutputs = len(proc.downstreams)
             
             if nInputs == 0 or nOutputs == 0:
-                print("Error module:", name, "with nInputs =", nInputs, "nOutputs =", nOutputs)
-                exit(0)
+                errorMsg += "Error module: " + name + " with nInputs = " + str(nInputs) + " nOutputs = " + str(nOutputs) + "\n"
+
+        if errorMsg != "":
+            print(errorMsg)
+            exit(1)
 
 
         

--- a/bodge/TF_L1L2_tb_writer.vhd.bodge
+++ b/bodge/TF_L1L2_tb_writer.vhd.bodge
@@ -1,9 +1,9 @@
   -- A bodge for TrackBuilder to write TF concatenated track+stub data for L1L2.
   -- (Needed to compare with emData/).
-  writeTF_L1L2_464 : entity work.FileWriterFIFO
+  writeTF_L1L2_484 : entity work.FileWriterFIFO
   generic map (
     FILE_NAME  => FILE_OUT_TF&"L1L2"&outputFileNameEnding,
-    FIFO_WIDTH  => 478
+    FIFO_WIDTH  => 484
   )
   port map (
     CLK => CLK,

--- a/bodge/TF_L2L3_tb_writer.vhd.bodge
+++ b/bodge/TF_L2L3_tb_writer.vhd.bodge
@@ -1,9 +1,9 @@
   -- A bodge for TrackBuilder to write TF concatenated track+stub data for L2L3.
   -- (Needed to compare with emData/).
-  writeTF_L2L3_418 : entity work.FileWriterFIFO
+  writeTF_L2L3_438 : entity work.FileWriterFIFO
   generic map (
     FILE_NAME  => FILE_OUT_TF&"L2L3"&outputFileNameEnding,
-    FIFO_WIDTH  => 432
+    FIFO_WIDTH  => 438
   )
   port map (
     CLK => CLK,

--- a/bodge/TF_L3L4_tb_writer.vhd.bodge
+++ b/bodge/TF_L3L4_tb_writer.vhd.bodge
@@ -1,9 +1,9 @@
   -- A bodge for TrackBuilder to write TF concatenated track+stub data for L3L4.
   -- (Needed to compare with emData/).
-  writeTF_L3L4_366 : entity work.FileWriterFIFO
+  writeTF_L3L4_386 : entity work.FileWriterFIFO
   generic map (
     FILE_NAME  => FILE_OUT_TF&"L3L4"&outputFileNameEnding,
-    FIFO_WIDTH  => 380
+    FIFO_WIDTH  => 386
   )
   port map (
     CLK => CLK,

--- a/bodge/TF_L5L6_tb_writer.vhd.bodge
+++ b/bodge/TF_L5L6_tb_writer.vhd.bodge
@@ -1,9 +1,9 @@
   -- A bodge for TrackBuilder to write TF concatenated track+stub data for L5L6.
   -- (Needed to compare with emData/).
-  writeTF_L5L6_268 : entity work.FileWriterFIFO
+  writeTF_L5L6_288 : entity work.FileWriterFIFO
   generic map (
     FILE_NAME  => FILE_OUT_TF&"L5L6"&outputFileNameEnding,
-    FIFO_WIDTH  => 282
+    FIFO_WIDTH  => 288
   )
   port map (
     CLK => CLK,

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -269,7 +269,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
             string_tmp = writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc, memInfo.bxbitwidth)
             # A bodge for TrackBuilder to write TF concatenated track+stub data.
             # (Needed to compare with emData/).
-            if mtypeB == 'TW_98':
+            if mtypeB == 'TW_104':
                 for m in memDict[mtypeB]:
                     memName = m.inst
                     seed = memName[-4:]
@@ -334,7 +334,7 @@ def writeTestBench(tbfunc, topfunc, process_list, memDict, memInfoDict, memPrint
     string_constants = writeTBConstants(memDict, memInfoDict, notfinal_procs+[final_proc], memPrintsDir, sector)
     # A bodge for TrackBuilder to write TF concatenated track+stub data.
     # (Needed to compare with emData/).
-    if 'TW_98' in memInfoDict.keys():
+    if 'TW_104' in memInfoDict.keys():
       fileTF = open("bodge/TF_tb_constants.vhd.bodge")
       string_constants += fileTF.read();
 


### PR DESCRIPTION
This PR accompanies cms-L1TK/firmware-hls#309 and updates the widths of some ports to accommodate the new bits for the phi regions of the seed stub indices.

Unrelated, this PR also updates the error message that is printed in case there are modules in the wires file that have no inputs or no outputs. The message now contains all such modules, instead of only the first. This is useful for debugging the wires file.