### PR TITLE
TrackBuilder updates

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -6,7 +6,7 @@
 #from collections import deque
 from TrackletGraph import MemModule, ProcModule, MemTypeInfoByKey
 
-from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeProcTrackStreamLHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts
+from WriteVHDLSyntax import writeStartSwitchAndInternalBX, writeProcControlSignalPorts, writeProcBXPort, writeProcMemoryLHSPorts, writeProcMemoryRHSPorts, writeProcCombination, writeProcDTCLinkRHSPorts, writeProcTrackStreamLHSPorts, writeInputLinkWordPort, writeInputLinkPhiBinsPort, writeLastTrackPorts, writeLUTPorts, writeLUTParameters, writeLUTCombination, writeLUTWires, writeLUTMemPorts
 import re
 # This dictionary preserves key order. 
 # (Requires python >= 2.7. And can be replace with normal dict for >= 3.7)
@@ -1170,6 +1170,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     string_bx_out = ""
     # memory ports
     string_mem_ports = ""
+    # last track ports
+    string_last_track_ports = ""
     # module string
     module_str = ""
 
@@ -1202,6 +1204,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             module_str += writeLUTCombination(module, argname, string_ports, string_parameters)
             str_ctrl_wire += writeLUTWires(argname, module, innerPS, outerPS)
             string_mem_ports += writeLUTMemPorts(argname, module)
+        elif argtype.startswith("bool") and argtype.endswith("&") and argname == "done":
+            string_last_track_ports = writeLastTrackPorts(is_open = not module.is_last)
         else:
             # Given argument name, search for the matched port name in the mem lists
             foundMatch = False
@@ -1307,6 +1311,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     string_ports += string_bx_in
     string_ports += string_bx_out
     string_ports += string_mem_ports
+    string_ports += string_last_track_ports
     string_ports += string_luts
     string_ports.rstrip(",\n")
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -555,6 +555,9 @@ def writeControlSignals_interface(initial_proc, final_proc, notfinal_procs, dela
     string_ctrl_signals += "    "+final_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
     string_ctrl_signals += "    "+final_proc+"_bx_out_vld : out std_logic;\n"
     string_ctrl_signals += "    "+final_proc+"_done   : out std_logic;\n"
+    if final_proc.startswith("FT"):
+      string_ctrl_signals += "    "+final_proc+"_last_track   : out std_logic;\n"
+      string_ctrl_signals += "    "+final_proc+"_last_track_vld   : out std_logic;\n"
     # Extra output ports if debug info must be sent to test-bench.
     for mid_proc in notfinal_procs:
         string_ctrl_signals += "    "+mid_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
@@ -750,6 +753,9 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
     string_ctrl_signals += ("  signal "+final_proc+"_bx_out").ljust(str_len)+": std_logic_vector(2 downto 0) := (others => '1');\n"
     string_ctrl_signals += ("  signal "+final_proc+"_bx_out_vld").ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += ("  signal "+final_proc+"_done").ljust(str_len)+": std_logic := '0';\n"
+    if final_proc.startswith("FT"):
+      string_ctrl_signals += ("  signal "+final_proc+"_last_track").ljust(str_len)+": std_logic := '0';\n"
+      string_ctrl_signals += ("  signal "+final_proc+"_last_track_vld").ljust(str_len)+": std_logic := '0';\n"
 
     first_mem = "" # The first memory of the chain
     found_first_mem = False
@@ -866,6 +872,9 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     string_fwblock_inst += ("        " + final_proc + "_bx_out").ljust(str_len) + "=> " + final_proc + "_bx_out,\n"
     string_fwblock_inst += ("        " + final_proc + "_bx_out_vld").ljust(str_len) + "=> " + final_proc + "_bx_out_vld,\n"
     string_fwblock_inst += ("        " + final_proc + "_done").ljust(str_len) + "=> " + final_proc + "_done,\n"
+    if final_proc.startswith("FT"):
+      string_fwblock_inst += ("        " + final_proc + "_last_track").ljust(str_len) + "=> " + final_proc + "_last_track,\n"
+      string_fwblock_inst += ("        " + final_proc + "_last_track_vld").ljust(str_len) + "=> " + final_proc + "_last_track_vld,\n"
 
     # Add debug signals if considering intermediate memories
     if notfinal_procs:
@@ -1242,6 +1251,16 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
                     string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent("+str(i)+"),\n"
 
     return string_mem_ports
+
+def writeLastTrackPorts(is_open):
+    string_last_track_port = "      done        => "
+    if is_open:
+      string_last_track_port += "open,\n"
+    else:
+      string_last_track_port += "FT_last_track,\n"
+    string_last_track_port += "      done_ap_vld => FT_last_track_vld,\n"
+
+    return string_last_track_port
 
 def writeLUTPorts(argname,lut):
     string_lut_ports = ""

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1016,18 +1016,19 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned):
     return string_mem 
 
 
-def writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc, bxbitwidth):
+def writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc):
     """
     # VHDL test bench: write the loop that writes the input to all FIFO memories to text files
     # Inputs:
     #   mtypeB:     the name of the memory type, including the number of bits (e.g. TPROJ_58)
     #   proc:       the processing module that writes to this memory.
-    #   bxbitwidth: number of bits for the bunch-crossings. I.e. one page per bx.
     """
 
     memList = memDict[mtypeB]
 
     string_mem = ""
+
+    memWidth = int(mtypeB.split("_")[-1])
 
     for memMod in memList:
         mem = memMod.inst
@@ -1041,7 +1042,7 @@ def writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc, bxbitwidth):
         string_mem += "    port map (\n"
         string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
         string_mem += "      DONE".ljust(str_len)+"=> "+proc+"_DONE,\n"
-        string_mem += "      WRITE_EN".ljust(str_len)+"=> "+mem+"_stream_A_write,\n"
+        string_mem += "      WRITE_EN".ljust(str_len)+"=> ("+mem+"_stream_A_write and "+mem+"_stream_AV_din(" + str(memWidth - 1) + ")),\n"
         string_mem += "      FULL_NEG".ljust(str_len)+"=> "+mem+"_stream_A_full_neg,\n"
         string_mem += "      DATA".ljust(str_len)+"=> "+mem+"_stream_AV_din\n"
         string_mem += "    );\n"

--- a/bodge/TF_L1L2_tb_writer.vhd.bodge
+++ b/bodge/TF_L1L2_tb_writer.vhd.bodge
@@ -8,7 +8,7 @@
   port map (
     CLK => CLK,
     DONE => FT_DONE,
-    WRITE_EN => TW_L1L2_stream_A_write,
+    WRITE_EN => (TW_L1L2_stream_A_write and TW_L1L2_stream_AV_din(103)),
     FULL_NEG => TW_L1L2_stream_A_full_neg,
     DATA => TW_L1L2_stream_AV_din&BW_L1L2_L3_stream_AV_din&BW_L1L2_L4_stream_AV_din&BW_L1L2_L5_stream_AV_din&BW_L1L2_L6_stream_AV_din&emptyDiskStub&emptyDiskStub&emptyDiskStub&emptyDiskStub
   );

--- a/bodge/TF_L2L3_tb_writer.vhd.bodge
+++ b/bodge/TF_L2L3_tb_writer.vhd.bodge
@@ -8,7 +8,7 @@
   port map (
     CLK => CLK,
     DONE => FT_DONE,
-    WRITE_EN => TW_L2L3_stream_A_write,
+    WRITE_EN => (TW_L2L3_stream_A_write and TW_L2L3_stream_AV_din(103)),
     FULL_NEG => TW_L2L3_stream_A_full_neg,
     DATA => TW_L2L3_stream_AV_din&BW_L2L3_L1_stream_AV_din(&BW_L2L3_L4_stream_AV_din&BW_L2L3_L5_stream_AV_din&emptyDiskStub&emptyDiskStub&emptyDiskStub&emptyDiskStub
   );

--- a/bodge/TF_L3L4_tb_writer.vhd.bodge
+++ b/bodge/TF_L3L4_tb_writer.vhd.bodge
@@ -8,7 +8,7 @@
   port map (
     CLK => CLK,
     DONE => FT_DONE,
-    WRITE_EN => TW_L3L4_stream_A_write,
+    WRITE_EN => (TW_L3L4_stream_A_write and TW_L3L4_stream_AV_din(103)),
     FULL_NEG => TW_L3L4_stream_A_full_neg,
     DATA => TW_L3L4_stream_AV_din&BW_L3L4_L1_stream_AV_din&BW_L3L4_L2_stream_AV_din&BW_L3L4_L5_stream_AV_din&BW_L3L4_L6_stream_AV_din&emptyDiskStub&emptyDiskStub
   );

--- a/bodge/TF_L5L6_tb_writer.vhd.bodge
+++ b/bodge/TF_L5L6_tb_writer.vhd.bodge
@@ -8,7 +8,7 @@
   port map (
     CLK => CLK,
     DONE => FT_DONE,
-    WRITE_EN => TW_L5L6_stream_A_write,
+    WRITE_EN => (TW_L5L6_stream_A_write and TW_L5L6_stream_AV_din(103)),
     FULL_NEG => TW_L5L6_stream_A_full_neg,
     DATA => TW_L5L6_stream_AV_din&BW_L5L6_L1_stream_AV_din&BW_L5L6_L2_stream_AV_din&BW_L5L6_L3_stream_AV_din&BW_L5L6_L4_stream_AV_din
   );

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -266,7 +266,7 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
         up_proc = notfinal_procs[notfinal_procs.index(proc)-1] if notfinal_procs and proc != notfinal_procs[0] and proc in notfinal_procs else "" # The previous processing module
 
         if memInfo.isFIFO:
-            string_tmp = writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc, memInfo.bxbitwidth)
+            string_tmp = writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc)
             # A bodge for TrackBuilder to write TF concatenated track+stub data.
             # (Needed to compare with emData/).
             if mtypeB == 'TW_104':


### PR DESCRIPTION
This PR accompanies cms-L1TK/firmware-hls#312, and adds the new "done" port to the generated instances of the TrackBuilder, as well as makes sure the generated test benches only write valid words from the TrackBuilder.