### PR TITLE
update for new binned memories and first split-fpga chain

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -208,7 +208,10 @@ class TrackletGraph(object):
         elif mem.mtype == "AllStubs" or mem.mtype == "InputLink":
             mem.bitwidth = 36
         elif mem.mtype == "AllInnerStubs":
-            mem.bitwidth = 51 # FIXME - only correct for barrel PS
+            if disk>-1:
+              mem.bitwidth = 52
+            else:
+              mem.bitwidth = 51
         elif mem.mtype == "DTCLink":
             mem.bitwidth = 39
         elif mem.mtype == "StubPairs":

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1281,7 +1281,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                         else:
                             string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory,split)
                     if portname.find("trackpar") != -1 and (module.mtype == "TrackletCalculator" or module.mtype == "TrackletProcessor"):
-                        string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
+                        string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory,split)
                     elif portname.find("trackpar") != -1 and module.mtype == "PurgeDuplicates":
                         string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)
 
@@ -1333,7 +1333,7 @@ def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay, s
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMRCM,
                                          matchArgPortNames_VMRCM,
-                                         first_of_type, extraports, delay)
+                                         first_of_type, extraports, delay, split)
     elif module.mtype == 'TrackletEngine':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TE,

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1270,7 +1270,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                     # Add the memory instance to the port string
                     # Assumes a sorted memModuleList due to arrays
                     if portname.replace("inner","").find("in") != -1:
-                        if "DL" in memory.inst: # DTCLink
+                        if "DL" in memory.inst and "AS" not in memory.inst: # DTCLink
                             string_mem_ports += writeProcDTCLinkRHSPorts(tmp_argname,memory)
                         else:
                             string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1128,11 +1128,8 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                               f_matchArgPortNames, first_of_type, extraports,delay):
     ####
     # function name
-    assert(module.mtype in ['InputRouter', 'VMRouter', 'VMRouterCM', 'TrackletEngine', 'TrackletCalculator',
-                            'TrackletProcessor', 'ProjectionRouter', 'MatchEngine', 'MatchCalculator',
+    assert(module.mtype in ['InputRouter', 'VMRouterCM', 'TrackletProcessor',
                             'MatchProcessor', 'FitTrack', 'TrackBuilder', 'PurgeDuplicate'])
-
-    combined = (module.mtype == "VMRouterCM" or module.mtype == "TrackletProcessor" or module.mtype == "MatchProcessor")
 
     # Add internal BX wire and start registers
     str_ctrl_wire = ""
@@ -1276,17 +1273,17 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                         if "DL" in memory.inst: # DTCLink
                             string_mem_ports += writeProcDTCLinkRHSPorts(tmp_argname,memory)
                         else:
-                            string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory,combined=combined)
+                            string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)
 
                     if portname.replace("outer","").find("out") != -1:
                         if memory.isFIFO():
                             string_mem_ports += writeProcTrackStreamLHSPorts(tmp_argname,memory)
                         else:
-                            string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory,combined=combined)
+                            string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
                     if portname.find("trackpar") != -1 and (module.mtype == "TrackletCalculator" or module.mtype == "TrackletProcessor"):
-                        string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory,combined=combined)
+                        string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
                     elif portname.find("trackpar") != -1 and module.mtype == "PurgeDuplicates":
-                        string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory,combined=combined)
+                        string_mem_ports += writeProcMemoryRHSPorts(tmp_argname,memory)
 
                     # Remove the already added module and name from the lists
                     portNameList.remove(portname)

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1125,7 +1125,7 @@ def parseProcFunction(proc_name, fname_def):
     return arg_types_list, arg_names_list, templ_pars_list
 
 def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
-                              f_matchArgPortNames, first_of_type, extraports,delay):
+                              f_matchArgPortNames, first_of_type, extraports,delay,split=False):
     ####
     # function name
     assert(module.mtype in ['InputRouter', 'VMRouterCM', 'TrackletProcessor',
@@ -1279,7 +1279,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
                         if memory.isFIFO():
                             string_mem_ports += writeProcTrackStreamLHSPorts(tmp_argname,memory)
                         else:
-                            string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
+                            string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory,split)
                     if portname.find("trackpar") != -1 and (module.mtype == "TrackletCalculator" or module.mtype == "TrackletProcessor"):
                         string_mem_ports += writeProcMemoryLHSPorts(tmp_argname,memory)
                     elif portname.find("trackpar") != -1 and module.mtype == "PurgeDuplicates":
@@ -1318,7 +1318,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     return str_ctrl_wire,module_str
 
 ################################
-def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay):
+def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay, split = False):
     if module.mtype == 'InputRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_IR,
@@ -1343,7 +1343,7 @@ def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay):
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TP,
                                          matchArgPortNames_TP,
-                                         first_of_type, extraports, delay)
+                                         first_of_type, extraports, delay, split)
     elif module.mtype == 'TrackletCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TC,

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -274,7 +274,9 @@ def writeMemoryUtil(memDict, memInfoDict):
                 tName = "t_"+mtypeB+"_NENTADDR"
                 ss += "  subtype "+tName+" is std_logic_vector(4 downto 0);\n"
               else:
-                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
+                ss += "  subtype "+tName+" is std_logic_vector(63 downto 0);\n"
+                tName = "t_"+mtypeB+"_NENTADDR"
+                ss += "  subtype "+tName+" is std_logic_vector(3 downto 0);\n"
             else:
               ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
             if memInfo.is_binned:
@@ -389,7 +391,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 wirelist += "  signal "+mem+"_AV_readaddr   : "
                 wirelist += "t_"+mtypeB+"_AADDR;\n"
                 wirelist += "  signal "+mem+"_AV_dout       : "
-                wirelist += "t_"+mtypeB+"_ADATA;\n" 
+                wirelist += "t_"+mtypeB+"_ADATA;\n"
             else:
                 wirelist += "  signal "+mem+"_enb          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
@@ -404,8 +406,16 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                         wirelist += "  signal "+mem+"_AV_dout_mask : "
                         wirelist += "t_"+mtypeB+"_MASK; -- (#page)(#bin)\n"  
                         if "VMSTE" in mtypeB :
-                            wirelist += "  signal "+mem+"_AAV_dout_nent : "
+                            wirelist += "  signal "+mem+"_enb_nent         : "
+                            wirelist += "t_"+mtypeB+"_1b;\n"
+                            wirelist += "  signal "+mem+"_V_addr_nent   : "
+                            wirelist += "t_"+mtypeB+"_NENTADDR;\n"
+                            wirelist += "  signal "+mem+"_AV_dout_nent : "
                             wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
+                            wirelist += "  signal "+mem+"_V_datatmp : "
+                            wirelist += "std_logic_vector(79 downto 0);\n"
+                            wirelist += "  signal "+mem+"_V_masktmp : "
+                            wirelist += "std_logic_vector(64*2-1 downto 0);\n"
                         else:
                             wirelist += "  signal "+mem+"_enb_nentA : "
                             wirelist += "t_"+mtypeB+"_1b;\n"
@@ -442,6 +452,11 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+"*PAGE_LENGTH_CM,\n"
             delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
 
+        if "VMSTE" in memList[0].inst: 
+            parameterlist += "        ADDR_WIDTH      => 4,\n"
+            parameterlist += "        NUM_PHI_BINS    => 8,\n"
+            parameterlist += "        NUM_RZ_BINS     => 8,\n"
+            parameterlist += "        NUM_COPY        => 5\n"
         if "VMSME_D" in memList[0].inst: # VMSME memories have 16 bins in the disks
             parameterlist += "        NUM_MEM_BINS    => 16,\n"
             parameterlist += "        NUM_ENTRIES_PER_MEM_BINS => 8,\n"
@@ -488,9 +503,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         portlist += "        regceb    => '1',\n"
         if combined :
             for inst in range(0,nmem) :
-                portlist += "        enb"+str(inst)+"       => "+mem+"_A_enb("+str(inst)+"),\n"
-                portlist += "        addrb"+str(inst)+"     => "+mem+"_AV_readaddr("+str(inst)+"),\n"
-                portlist += "        doutb"+str(inst)+"     => "+mem+"_AV_dout("+str(inst)+"),\n"
+                if "VMSME" in mem :
+                    portlist += "        enb"+str(inst)+"       => "+mem+"_A_enb("+str(inst)+"),\n"
+                    portlist += "        addrb"+str(inst)+"     => "+mem+"_AV_readaddr("+str(inst)+"),\n"
+                    portlist += "        doutb"+str(inst)+"     => "+mem+"_AV_dout("+str(inst)+"),\n"
         else:
             portlist += "        enb       => "+mem+"_enb,\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"
@@ -500,10 +516,27 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         if memList[0].has_numEntries_out:
             if memList[0].is_binned:
                 if combined:
-                    portlist += "        mask_o    => "+mem+"_AV_dout_mask,\n"
                     if "VMSTE" in mtypeB :
-                        portlist += "        nent_o    => "+mem+"_AAV_dout_nent,\n"
+                        #portlist += "        nent_o    => "+mem+"_AAV_dout_nent,\n"
+                        portlist += "        enb       => ("
+                        portlist += mem+"_A_enb(4),"
+                        portlist += mem+"_A_enb(3),"
+                        portlist += mem+"_A_enb(2),"
+                        portlist += mem+"_A_enb(1),"
+                        portlist += mem+"_A_enb(0)),\n"
+                        portlist += "        addrb     => ("
+                        portlist += mem+"_AV_readaddr(4),"
+                        portlist += mem+"_AV_readaddr(3),"
+                        portlist += mem+"_AV_readaddr(2),"
+                        portlist += mem+"_AV_readaddr(1),"
+                        portlist += mem+"_AV_readaddr(0)),\n"
+                        portlist += "        doutb     => "+mem+"_V_datatmp,\n"
+                        portlist += "        enb_nent  => "+mem+"_enb_nent,\n"
+                        portlist += "        addr_nent  => "+mem+"_V_addr_nent,\n"
+                        portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
+                        portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
                     else:
+                        portlist += "        mask_o    => "+mem+"_AV_dout_mask,\n"
                         portlist += "        enb_nentA  => "+mem+"_enb_nentA,\n"
                         portlist += "        enb_nentB  => "+mem+"_enb_nentB,\n"
                         portlist += "        addr_nentA  => "+mem+"_V_addr_nentA,\n"
@@ -524,7 +557,22 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         if memList[0].is_binned:
             module =  memList[0].downstreams[0].inst[0:3]
             if module == "TP_" :
-                mem_str += "    "+mem+" : entity work.tf_mem_bin_cm5\n"
+                mem_str += "    "+mem+"_dataformat : entity work.vmstub16dout5\n"
+                mem_str += "      port map (\n"
+                mem_str += "        datain => "+mem+"_V_datatmp,\n"
+                mem_str += "        dataout0 => "+mem+"_AV_dout(0),\n"
+                mem_str += "        dataout1 => "+mem+"_AV_dout(1),\n"
+                mem_str += "        dataout2 => "+mem+"_AV_dout(2),\n"
+                mem_str += "        dataout3 => "+mem+"_AV_dout(3),\n"
+                mem_str += "        dataout4 => "+mem+"_AV_dout(4)\n"
+                mem_str += "      );\n\n"
+                mem_str += "    "+mem+"_maskformat : entity work.vmstub16mask\n"
+                mem_str += "      port map (\n"
+                mem_str += "        datain => "+mem+"_V_masktmp,\n"
+                mem_str += "        dataout0 => "+mem+"_AV_dout_mask(0),\n"
+                mem_str += "        dataout1 => "+mem+"_AV_dout_mask(1)\n"
+                mem_str += "      );\n\n"
+                mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
             elif module == "MP_" :
                 mem_str += "    "+mem+" : entity work.tf_mem_bin_cm4\n"
             else:
@@ -1199,6 +1247,10 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
         #First branch is for combined modules
         if combined:
             if mem.mtype == "VMStubsTEOuter" :
+                if "VMSTE" in mem.mtype_short() :
+                    string_mem_ports += "      "+argname+"_nentries_V_ce0 => "+mem.mtype_short()+"_"+mem.var()+"_enb_nent,\n"
+                    string_mem_ports += "      "+argname+"_nentries_V_address0 => "+mem.mtype_short()+"_"+mem.var()+"_V_addr_nent,\n"
+                    string_mem_ports += "      "+argname+"_nentries_V_q0 => "+mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent,\n"
                 for i in range(0,2**mem.bxbitwidth):
                     if mem.is_binned:
                         for j in range(0,8):
@@ -1208,13 +1260,14 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
                                     string_mem_ports += ", "
                                 string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AV_dout_mask("+str(i)+")("+str(j+(7-k)*8)+")"
                             string_mem_ports += "),\n"
-                        for j in range(0,8):
-                            string_mem_ports += "      "+argname+"_nentries8_"+str(i)+"_V_"+str(j)+"     => ("
-                            for k in range(0, 8) :
-                                if k != 0 :
-                                    string_mem_ports += ", "
-                                string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AAV_dout_nent("+str(i)+")("+str(j+(7-k)*8)+")"
-                            string_mem_ports += "),\n"
+                        if "VMSTE" not in mem.mtype_short() :
+                            for j in range(0,8):
+                                string_mem_ports += "      "+argname+"_nentries8_"+str(i)+"_V_"+str(j)+"     => ("
+                                for k in range(0, 8) :
+                                    if k != 0 :
+                                        string_mem_ports += ", "
+                                        string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AAV_dout_nent("+str(i)+")("+str(j+(7-k)*8)+")"
+                                string_mem_ports += "),\n"
                     else:
                         string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
                         string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent("+str(i)+"),\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -809,7 +809,7 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
     string_constants += "  constant INST_TOP_TF".ljust(str_len) + ": integer := 1; \n"
     string_constants += "  --=========================================================================\n\n"
     string_constants += "  constant CLK_PERIOD".ljust(str_len) + ": time    := 4 ns;       --! 250 MHz\n"
-    string_constants += "  constant DEBUG".ljust(str_len) + ": boolean := False;      --! Debug off/on\n"
+    string_constants += "  constant DEBUG".ljust(str_len) + ": boolean := false;      --! Debug off/on\n"
  
     # Write delay and input/output file name signals
     string_input_tmp = "  -- File directories and the start of the file names that memories have in common\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -426,7 +426,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         disk = ""
         if memInfo.is_binned:
             nmem = getVMStubNCopy(memmod)
-            if "_D" in mem:
+            if "VMSME_D" in mem:
                 disk="DISK"
 
         parameterlist = ""
@@ -479,7 +479,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                     #if "16" in mtypeB :
                     #    vmstubwidth = 16 
                     disk=""
-                    if "_D" in mem:
+                    if "VMSME_D" in mem:
                         disk="DISK"
                     wirelist += "  signal "+mem+"_AV_dout_mask : "
                     wirelist += "t_"+mtypeB+"_MASK"+disk+"; -- (#page)(#bin)\n"  
@@ -501,7 +501,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         else :
             if memInfo.is_binned:
                 disk=""
-                if "_D" in mem:
+                if "VMSME_D" in mem:
                     disk="DISK"
                 wirelist += "  signal "+mem+"_V_datatmp : "
                 wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
@@ -523,7 +523,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             delay_parameterlist +="        NUM_PAGES       => "+str(num_pages)+",\n"
             if memInfo.is_binned:
                 disk=""
-                if "_D" in mem:
+                if "VMSME_D" in mem:
                     disk = "*2"
                 delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+disk+"*PAGE_LENGTH_CM,\n"
             delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
@@ -531,15 +531,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         ncopy = getVMStubNCopy(memmod);
 
 
-        if "VMSTE_L" in mem: 
+        if "VMSTE_" in mem: 
             parameterlist += "        ADDR_WIDTH      => 4,\n"
             parameterlist += "        NUM_PHI_BINS    => 8,\n"
             parameterlist += "        NUM_RZ_BINS     => 8,\n"
-            parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
-        if "VMSTE_D" in mem: 
-            parameterlist += "        ADDR_WIDTH      => 4,\n"
-            parameterlist += "        NUM_PHI_BINS    => 8,\n"
-            parameterlist += "        NUM_RZ_BINS     => 16,\n"
             parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
         if "VMSME_L" in mem: # VMSME memories have 16 bins in the disks
             parameterlist += "        ADDR_WIDTH      => 4,\n"
@@ -641,7 +636,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                     mem_str += "        dataout"+str(i)+" => "+mem+"_AV_dout("+str(i)+")\n"
             mem_str += "      );\n\n"
             disk = ""
-            if "_D" in mem:
+            if "VMSME_D" in mem:
                 disk = "DISK"
             mem_str += "    "+mem+"_maskformat : entity work.vmstub"+str(nbx)+"mask"+disk+"\n"
             mem_str += "      port map (\n"
@@ -711,7 +706,7 @@ def writeMemoryLHSPorts_interface(memList, mtypeB, extraports=False):
 
         disk = ""
         if memMod.is_binned :
-            if "_D" in mem:
+            if "VMSME_D" in mem:
                 disk = "DISK"
 
         string_input_mems += "    "+mem+"_wea        : "+direction+" t_"+mtypeB+"_1b;\n"
@@ -755,7 +750,7 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo, memDict):
       mem = memMod.inst
 
       disk=""
-      if "_D" in mem:
+      if "VMSME_D" in mem:
           disk="DISK"
 
       if "VMSME" in mtypeB:
@@ -948,7 +943,7 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
                 # Add nentries signal if last memory of the chain
                 if memInfo.is_binned: #FIXME including both read and write signals
                     disk = ""
-                    if "_D" in mem:
+                    if "VMSME_D" in mem:
                         disk = "DISK"
                     string_ctrl_signals += ("  signal "+mem+"_wea").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
@@ -982,7 +977,7 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
                 mem = memMod.inst
                 disk = ""
                 if memMod.is_binned:
-                    if "_D" in mem:
+                    if "VMSME_D" in mem:
                         disk = "DISK"
 
                 string_ctrl_signals += ("  signal "+mem+"_wea").ljust(str_len)+": "
@@ -1135,7 +1130,10 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
         string_mem += "        FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mtypeB+"&\""+mem+"\"&outputFileNameEnding,\n"
         string_mem += "        RAM_WIDTH".ljust(str_len)+"=> " + mtypeB.split("_")[1] + ",\n"
         if is_cm and is_binned :
-            string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 1024,\n"
+            if "VMSME_D" in mem:
+                string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 2048,\n"
+            else:
+                string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 1024,\n"
         string_mem += "        NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
         string_mem += "      )\n"
         string_mem += "      port map (\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -858,7 +858,7 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
     string_constants += "  constant inputFileNameEnding".ljust(str_len) + ": string := \"_" + sector + ".dat\"; -- " + sector + " specifies the nonant/sector the testvectors represent\n"
     string_constants += "  constant outputFileNameEnding".ljust(str_len) + ": string := \".txt\";\n"
     string_constants += "  constant debugFileNameEnding".ljust(str_len) + ": string := \".debug.txt\";\n\n"
-    string_constants += "  signal dummy : STD_LOGIC := '0';\n\n -- dummy tb signal for inputs into sectorproc"
+    string_constants += "  signal dummy : STD_LOGIC := '0';\n\n -- dummy tb signal for inputs into sectorproc\n"
     string_constants += "  signal dummyaddr : t_as_36_addr := (others => '0');\n\n -- dummy tb signal for inputs into sectorproc"
 
     return string_constants

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -449,7 +449,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
             wirelist += "  signal "+mem+"_din_delay         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
-            if (interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB):
+            if ((interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB)) and "VMSME" not in mtypeB:
                 wirelist += "  signal "+mem+"_wea          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_writeaddr   : "
@@ -693,7 +693,7 @@ def writeMemoryLHSPorts_interface(memList, mtypeB, extraports=False):
     # Top-level interface: input memories' ports.
     """
 
-    if (extraports):
+    if (extraports or "VMSME" in mtypeB):
         direction = "out" # carry debug info to test-bench
     else:
         direction = "in"
@@ -824,7 +824,7 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
     string_constants += "  constant INST_TOP_TF".ljust(str_len) + ": integer := 1; \n"
     string_constants += "  --=========================================================================\n\n"
     string_constants += "  constant CLK_PERIOD".ljust(str_len) + ": time    := 4 ns;       --! 250 MHz\n"
-    string_constants += "  constant DEBUG".ljust(str_len) + ": boolean := false;      --! Debug off/on\n"
+    string_constants += "  constant DEBUG".ljust(str_len) + ": boolean := False;      --! Debug off/on\n"
  
     # Write delay and input/output file name signals
     string_input_tmp = "  -- File directories and the start of the file names that memories have in common\n"
@@ -1311,7 +1311,7 @@ def writeProcBXPort(modName,isInput,isInitial,delay):
             bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
     return bx_str
 
-def writeProcMemoryLHSPorts(argname,mem):
+def writeProcMemoryLHSPorts(argname,mem,split = False):
     """
     # Processing module port assignment: outputs to memories
     """
@@ -1326,13 +1326,20 @@ def writeProcMemoryLHSPorts(argname,mem):
         string_mem_ports += "      "+argname+"_dataarray_0_data_V_d0        => "
         string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_din,\n"
     else:
-        string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
-        string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => "
-        string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_wea,\n"
-        string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => "
-        string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_writeaddr,\n"
-        string_mem_ports += "      "+argname+"_dataarray_data_V_d0        => "
-        string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_din,\n"
+        if ("TPROJ" in mem.inst) and split: #set TPROJ to open for a split-FPGA project
+          string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => open,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => open,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_d0        => open,\n"
+  
+        else:
+          string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => "
+          string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_wea,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => "
+          string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_writeaddr,\n"
+          string_mem_ports += "      "+argname+"_dataarray_data_V_d0        => "
+          string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_din,\n"
 
 
     return string_mem_ports

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -178,7 +178,7 @@ def writeTBMemoryReadInstance(mtypeB, memDict, bxbitwidth, is_initial, is_binned
 
         mem = memMod.inst
     
-        if "DL" in mtypeB: # Special case for DTC links that reads from FIFOs
+        if "DL" in mtypeB and "AS" not in mtypeB: # Special case for DTC links that reads from FIFOs
             string_mem += "    read" + mem + " : entity work.FileReaderFIFO\n"
             string_mem += "  generic map (\n"
             memtmp = mem.replace("twoS","2S")
@@ -428,7 +428,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             wirelist += "t_"+mtypeB+"_ADDR;\n"
             wirelist += "  signal "+mem+"_din_delay         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
-            if (interface != -1 and not extraports) or (interface == 1 and extraports):
+            if (interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB):
                 wirelist += "  signal "+mem+"_wea          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_writeaddr   : "
@@ -474,6 +474,14 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 else:
                     wirelist += "  signal "+mem+"_AV_dout_nent  : "
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)\n"
+        else :
+          if memInfo.is_binned:
+            wirelist += "  signal "+mem+"_V_datatmp : "
+            wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
+            #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
+            wirelist += "  signal "+mem+"_V_masktmp : "
+            wirelist += "t_"+mtypeB+"_MASK_"+str(num_pages)+";\n"
+            #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
 
         # Write parameters
         parameterlist += "        RAM_WIDTH       => "+bitwidth+",\n"
@@ -687,7 +695,7 @@ def writeDTCLinkLHSPorts_interface(mtypeB, memDict):
 
     return string_input_mems
 
-def writeMemoryRHSPorts_interface(mtypeB, memInfo):
+def writeMemoryRHSPorts_interface(mtypeB, memInfo, memDict):
     """
     # Top-level interface: output memories' ports.
     # Inputs:
@@ -697,22 +705,34 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo):
 
     # Assume all memories of given type have same bxbitwidth.
     bxbitwidth =  memInfo.bxbitwidth
-
+    memList = memDict[mtypeB]
     string_output_mems = ""
-    string_output_mems += "    "+mtypeB+"_mem_A_enb          : in t_arr_"+mtypeB+"_1b;\n"
-    string_output_mems += "    "+mtypeB+"_mem_AV_readaddr    : in t_arr_"+mtypeB+"_ADDR;\n"
-    string_output_mems += "    "+mtypeB+"_mem_AV_dout        : out t_arr_"+mtypeB+"_DATA;\n"
+    for memMod in memList:
 
-    if memInfo.has_numEntries_out:
-        num_pages = 2**bxbitwidth
-        if memInfo.is_binned:
-            string_output_mems += "    "+mtypeB+"_mem_AAAV_dout_nent : "
-            string_output_mems += "out t_arr_"+mtypeB+"_NENT;\n"
-            string_output_mems += "    "+mtypeB+"_mem_AAV_dout_mask : "
-            string_output_mems += "out t_arr_"+mtypeB+"_MASK;\n"
-        else:
-            string_output_mems += "    "+mtypeB+"_mem_AAV_dout_nent  : "
-            string_output_mems += "out t_arr_"+mtypeB+"_NENT;\n" 
+      mem = memMod.inst
+
+      if "VMSME" in mtypeB:
+        string_output_mems += "    "+mem+"_A_enb          : in t_"+mtypeB+"_A1b;\n"
+        string_output_mems += "    "+mem+"_AV_readaddr    : in t_"+mtypeB+"_AADDR;\n"
+        string_output_mems += "    "+mem+"_AV_dout        : out t_"+mtypeB+"_ADATA;\n"
+        string_output_mems += "    "+mem+"_AV_dout_mask        : out t_"+mtypeB+"_MASK;\n"
+        string_output_mems += "    "+mem+"_enb_nent        : out t_"+mtypeB+"_1b;\n"
+        string_output_mems += "    "+mem+"_V_addr_nent        : out t_"+mtypeB+"_NENTADDR;\n"
+        string_output_mems += "    "+mem+"_AV_dout_nent       : out t_"+mtypeB+"_NENT;\n"
+      else:
+        string_output_mems += "    "+mem+"_enb          : in t_"+mtypeB+"_1b;\n"
+        string_output_mems += "    "+mem+"_V_readaddr    : in t_"+mtypeB+"_ADDR;\n"
+        string_output_mems += "    "+mem+"_V_dout        : out t_"+mtypeB+"_DATA;\n"
+        if memInfo.has_numEntries_out:
+            num_pages = 2**bxbitwidth
+            if memInfo.is_binned:
+                string_output_mems += "    "+mem+"_AV_dout_nent : "
+                string_output_mems += "out t_"+mtypeB+"_NENT;\n"
+                string_output_mems += "    "+mem+"_AV_dout_mask : "
+                string_output_mems += "out t_"+mtypeB+"_MASK;\n"
+            else:
+                string_output_mems += "    "+mem+"_AV_dout_nent  : "
+                string_output_mems += "out t_"+mtypeB+"_NENT;\n"
 
     return string_output_mems
 
@@ -848,7 +868,7 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
             first_mem = mtypeB
             found_first_mem = True
 
-        if "DL" in mtypeB: # Special case for DTCLink as it has a FIFO read interface
+        if "DL" in mtypeB and "AS" not in mtypeB: # Special case for DTCLink as it has a FIFO read interface
             memList = memDict[mtypeB]
 
             for memMod in memList :
@@ -877,21 +897,33 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
             for memMod in memList :
                 mem = memMod.inst
 
-                string_ctrl_signals += ("  signal "+mem+"_enb").ljust(str_len)+": "
-                string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= (others => '0');\n"
-                string_ctrl_signals += ("  signal "+mem+"_readaddr").ljust(str_len)+": "
-                string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => (others => '0'));\n"
-                string_ctrl_signals += ("  signal "+mem+"_dout").ljust(str_len)+": "
-                string_ctrl_signals += ("t_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => (others => '0'));\n"
                 # Add nentries signal if last memory of the chain
-                if memInfo.is_binned:
+                if memInfo.is_binned: #FIXME including both read and write signals
+                    string_ctrl_signals += ("  signal "+mem+"_wea").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
+                    string_ctrl_signals += ("  signal "+mem+"_writeaddr").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => '0');\n"
+                    string_ctrl_signals += ("  signal "+mem+"_din").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => '0');\n"
+                    string_ctrl_signals += ("  signal "+mem+"_enb").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_A1b").ljust(str_len2)+":= (others => '0');\n"
+                    string_ctrl_signals += ("  signal "+mem+"_readaddr").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_AADDR").ljust(str_len2)+":= (others => (others => '0'));\n"
+                    string_ctrl_signals += ("  signal "+mem+"_dout").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_ADATA").ljust(str_len2)+":= (others => (others => '0'));\n"
                     string_ctrl_signals += ("  signal "+mem+"_AAV_dout_nent").ljust(str_len)+": "
-                    string_ctrl_signals += ("t_"+mtypeB+"_NENT").ljust(str_len2)+":= (others => (others => (others => (others => '0')))); -- (#page)(#bin)\n"
+                    string_ctrl_signals += ("t_"+mtypeB+"_NENT").ljust(str_len2)+":= (others => '0'); -- (#page)(#bin)\n"
                     string_ctrl_signals += ("  signal "+mem+"_AV_dout_mask").ljust(str_len)+": "
-                    string_ctrl_signals += ("t_"+mtypeB+"_MASK").ljust(str_len2)+":= (others => (others => (others => '0'))); -- (#page)(#bin)\n"
+                    string_ctrl_signals += ("t_"+mtypeB+"_MASK").ljust(str_len2)+":= (others => (others => '0')); -- (#page)(#bin)\n"
                 else:
+                    string_ctrl_signals += ("  signal "+mem+"_enb").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
+                    string_ctrl_signals += ("  signal "+mem+"_readaddr").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => '0');\n"
+                    string_ctrl_signals += ("  signal "+mem+"_dout").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => '0');\n"
                     string_ctrl_signals += ("  signal "+mem+"_AV_dout_nent").ljust(str_len)+": "
-                    string_ctrl_signals += ("t_"+mtypeB+"_NENT").ljust(str_len2)+":= (others => (others => (others => '0'))); -- (#page)\n"
+                    string_ctrl_signals += ("t_"+mtypeB+"_NENT").ljust(str_len2)+":= (others => (others => '0')); -- (#page)\n"
         else: # RAM write interface
             memList = memDict[mtypeB]
 
@@ -945,7 +977,10 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     string_fwblock_inst += "        reset".ljust(str_len) + "=> reset,\n"
     string_fwblock_inst += ("        " + initial_proc + "_start").ljust(str_len) + "=> " + initial_proc + "_start,\n"
     string_fwblock_inst += ("        " + initial_proc + "_bx_in").ljust(str_len) + "=> " + initial_proc + "_bx_in,\n"
-    string_fwblock_inst += ("        " + final_proc + "_bx_out").ljust(str_len) + "=> " + final_proc + "_bx_out,\n"
+    if "FT" in final_proc:
+      string_fwblock_inst += ("        " + final_proc + "_bx_out").ljust(str_len) + "=> " + final_proc + "_bx_out,\n"
+    else:
+      string_fwblock_inst += ("        " + final_proc + "_bx_out_0").ljust(str_len) + "=> " + final_proc + "_bx_out,\n"
     string_fwblock_inst += ("        " + final_proc + "_bx_out_vld").ljust(str_len) + "=> " + final_proc + "_bx_out_vld,\n"
     string_fwblock_inst += ("        " + final_proc + "_done").ljust(str_len) + "=> " + final_proc + "_done,\n"
     if final_proc.startswith("FT"):
@@ -971,7 +1006,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
         for memMod in memList:
             mem = memMod.inst
             if memInfo.is_initial:
-                if "DL" in mtypeB: # Special case for DTCLink as it has FIFO input
+                if "DL" in mtypeB and "AS" not in mtypeB: # Special case for DTCLink as it has FIFO input
                     string_input += ("        "+mem+"_link_AV_dout").ljust(str_len) + "=> "+mem+"_link_AV_dout,\n"
                     string_input += ("        "+mem+"_link_empty_neg").ljust(str_len) + "=> "+mem+"_link_empty_neg,\n"
                     string_input += ("        "+mem+"_link_read").ljust(str_len) + "=> "+mem+"_link_read,\n"
@@ -988,14 +1023,22 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
                 else:
                     string_debug  += string_tmp
             elif memInfo.is_final:
-                string_output += ("        "+mem+"_enb").ljust(str_len) + "=> "+mem+"_enb,\n"
-                string_output += ("        "+mem+"_readaddr").ljust(str_len) + "=> "+mem+"_readaddr,\n"
-                string_output += ("        "+mem+"_dout").ljust(str_len) + "=> "+mem+"_dout,\n"
                 if memInfo.is_binned:
-                    string_output += ("        "+mem+"_dout_nent").ljust(str_len) + "=> "+mem+"_dout_nent,\n"
-                    string_output += ("        "+mem+"_dout_mask").ljust(str_len) + "=> "+mem+"_dout_mask,\n"
+                    string_debug += ("        "+mem+"_wea").ljust(str_len) + "=> "+mem+"_wea,\n"
+                    string_debug += ("        "+mem+"_writeaddr").ljust(str_len) + "=> "+mem+"_writeaddr,\n"
+                    string_debug += ("        "+mem+"_din").ljust(str_len) + "=> "+mem+"_din,\n"
+                    string_output += ("        "+mem+"_A_enb").ljust(str_len) + "=> "+mem+"_enb,\n"
+                    string_output += ("        "+mem+"_AV_readaddr").ljust(str_len) + "=> "+mem+"_readaddr,\n"
+                    string_output += ("        "+mem+"_AV_dout").ljust(str_len) + "=> "+mem+"_dout,\n"
+                    string_output += ("        "+mem+"_AV_dout_mask").ljust(str_len) + "=> open,\n" #FIXME
+                    string_output += ("        "+mem+"_enb_nent").ljust(str_len) + "=> open,\n"
+                    string_output += ("        "+mem+"_V_addr_nent").ljust(str_len) + "=> open,\n"
+                    string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> open,\n"
                 else:
-                    string_output += ("        "+mem+"_dout_nent").ljust(str_len) + "=> "+mem+"_dout_nent,\n"
+                    string_output += ("        "+mem+"_enb").ljust(str_len) + "=> "+mem+"_enb,\n"
+                    string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> "+mem+"_readaddr,\n"
+                    string_output += ("        "+mem+"_V_dout").ljust(str_len) + "=> "+mem+"_dout,\n"
+                    string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> "+mem+"_AV_dout_nent,\n"
             else:
                 string_debug += ("        "+mem+"_wea").ljust(str_len) + "=> "+mem+"_wea,\n"
                 string_debug += ("        "+mem+"_writeaddr").ljust(str_len) + "=> "+mem+"_writeaddr,\n"
@@ -1074,7 +1117,7 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned):
 
         string_mem += "    write"+mem+" : entity work.FileWriterFromRAM" + ("Binned\n" if is_binned else "\n")
         string_mem += "    generic map (\n"
-        string_mem += "      FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mem+"&outputFileNameEnding,\n"
+        string_mem += "      FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mtypeB+"&\""+mem+"\"&outputFileNameEnding,\n"
         string_mem += "      RAM_WIDTH".ljust(str_len)+"=> " + mtypeB.split("_")[1] + ",\n"
         string_mem += "      NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
         string_mem += "    )\n"
@@ -1083,7 +1126,10 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned):
         string_mem += "      ADDR".ljust(str_len)+"=> "+mem+"_readaddr,\n"
         string_mem += "      DATA".ljust(str_len)+"=> "+mem+"_dout,\n"
         string_mem += "      READ_EN".ljust(str_len)+"=> "+mem+"_enb,\n"
-        string_mem += "      NENT_ARR".ljust(str_len)+"=> "+mem+"_A" + ("A" if is_binned else "") + "V_dout_nent,\n"
+        if "VMSME" not in mem: #FIXME
+          string_mem += "      NENT_ARR".ljust(str_len)+"=> "+mem+"_A" + ("A" if is_binned else "") + "V_dout_nent,\n"
+        else:
+          string_mem += "      NENT_ARR".ljust(str_len)+"=> open,\n"
         string_mem += "      DONE".ljust(str_len)+"=> "+proc+"_DONE\n"
         string_mem += "    );\n"
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -311,11 +311,9 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
     #   memInfo = Info about each memory type (in MemTypeInfoByKey class)
     """
 
-    combined = False
     nmem = 0
 
     if memInfo.is_binned:
-        combined =  memInfo.downstream_mtype_short in ("TP", "MP")
         if memInfo.downstream_mtype_short == "TP" :
             nmem =  5
         if memInfo.downstream_mtype_short == "MP" :
@@ -372,7 +370,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 wirelist += "t_"+mtypeB+"_DATA;\n"
     
         if interface != 1:
-            if combined :
+            if memInfo.is_binned :
                 wirelist += "  signal "+mem+"_A_enb         : "
                 wirelist += "t_"+mtypeB+"_A1b;\n"
                 wirelist += "  signal "+mem+"_AV_readaddr   : "
@@ -389,38 +387,33 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
 
             if memInfo.has_numEntries_out:
                 if memInfo.is_binned:
-                    if combined:
-                        wirelist += "  signal "+mem+"_AV_dout_mask : "
-                        wirelist += "t_"+mtypeB+"_MASK; -- (#page)(#bin)\n"  
-                        if "VMSTE" in mtypeB :
-                            wirelist += "  signal "+mem+"_enb_nent         : "
-                            wirelist += "t_"+mtypeB+"_1b;\n"
-                            wirelist += "  signal "+mem+"_V_addr_nent   : "
-                            wirelist += "t_"+mtypeB+"_NENTADDR;\n"
-                            wirelist += "  signal "+mem+"_AV_dout_nent : "
-                            wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
-                            wirelist += "  signal "+mem+"_V_datatmp : "
-                            wirelist += "std_logic_vector(79 downto 0);\n"
-                            wirelist += "  signal "+mem+"_V_masktmp : "
-                            wirelist += "std_logic_vector(64*2-1 downto 0);\n"
-                        else:
-                            wirelist += "  signal "+mem+"_enb_nent         : "
-                            wirelist += "t_"+mtypeB+"_1b;\n"
-                            wirelist += "  signal "+mem+"_V_addr_nent   : "
-                            wirelist += "t_"+mtypeB+"_NENTADDR;\n"
-                            wirelist += "  signal "+mem+"_AV_dout_nent : "
-                            wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
-                            wirelist += "  signal "+mem+"_V_datatmp : "
-                            if "16" in mtypeB :
-                                wirelist += "std_logic_vector(63 downto 0);\n"
-                            else:
-                                wirelist += "std_logic_vector(67 downto 0);\n"
-                            wirelist += "  signal "+mem+"_V_masktmp : "
-                            wirelist += "std_logic_vector(64*4-1 downto 0);\n"
-                    else:
-                        wirelist += "  signal "+mem+"_AAV_dout_nent : "
+                    wirelist += "  signal "+mem+"_AV_dout_mask : "
+                    wirelist += "t_"+mtypeB+"_MASK; -- (#page)(#bin)\n"  
+                    if "VMSTE" in mtypeB :
+                        wirelist += "  signal "+mem+"_enb_nent         : "
+                        wirelist += "t_"+mtypeB+"_1b;\n"
+                        wirelist += "  signal "+mem+"_V_addr_nent   : "
+                        wirelist += "t_"+mtypeB+"_NENTADDR;\n"
+                        wirelist += "  signal "+mem+"_AV_dout_nent : "
                         wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
-
+                        wirelist += "  signal "+mem+"_V_datatmp : "
+                        wirelist += "std_logic_vector(79 downto 0);\n"
+                        wirelist += "  signal "+mem+"_V_masktmp : "
+                        wirelist += "std_logic_vector(64*2-1 downto 0);\n"
+                    else:
+                        wirelist += "  signal "+mem+"_enb_nent         : "
+                        wirelist += "t_"+mtypeB+"_1b;\n"
+                        wirelist += "  signal "+mem+"_V_addr_nent   : "
+                        wirelist += "t_"+mtypeB+"_NENTADDR;\n"
+                        wirelist += "  signal "+mem+"_AV_dout_nent : "
+                        wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
+                        wirelist += "  signal "+mem+"_V_datatmp : "
+                        if "16" in mtypeB :
+                            wirelist += "std_logic_vector(63 downto 0);\n"
+                        else:
+                            wirelist += "std_logic_vector(67 downto 0);\n"
+                        wirelist += "  signal "+mem+"_V_masktmp : "
+                        wirelist += "std_logic_vector(64*4-1 downto 0);\n"
                 else:
                     wirelist += "  signal "+mem+"_AV_dout_nent  : "
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)\n"
@@ -436,7 +429,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             delay_parameterlist +="        DELAY           => " + str(delay) +",\n"
             #enable to use non-default delay value
             delay_parameterlist +="        NUM_PAGES       => "+str(num_pages)+",\n"
-            if combined:
+            if memInfo.is_binned:
                 delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+"*PAGE_LENGTH_CM,\n"
             delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
 
@@ -460,7 +453,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         # Write ports
         portlist += "        clka      => clk,\n"
         if delay > 0:
-            if combined :
+            if memInfo.is_binned :
                 portlist += "        wea       => "+mem+"_wea_delay,\n"
                 portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
                 portlist += "        dina      => "+mem+"_din_delay,\n"
@@ -469,7 +462,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
                 portlist += "        dina      => "+mem+"_din_delay,\n"
         else:
-            if combined :
+            if memInfo.is_binned :
                 portlist += "        wea       => "+mem+"_wea,\n"
                 portlist += "        addra     => "+mem+"_writeaddr,\n"
                 portlist += "        dina      => "+mem+"_din,\n"
@@ -497,7 +490,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         portlist += "        clkb      => clk,\n"
         portlist += "        rstb      => '0',\n"
         portlist += "        regceb    => '1',\n"
-        if not combined :
+        if not memInfo.is_binned :
             portlist += "        enb       => "+mem+"_enb,\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"
             portlist += "        doutb     => "+mem+"_V_dout,\n"
@@ -505,52 +498,31 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
 
         if memList[0].has_numEntries_out:
             if memList[0].is_binned:
-                if combined:
-                    if "VMSTE" in mtypeB :
-                        portlist += "        enb       => ("
-                        portlist += mem+"_A_enb(4),"
-                        portlist += mem+"_A_enb(3),"
-                        portlist += mem+"_A_enb(2),"
-                        portlist += mem+"_A_enb(1),"
-                        portlist += mem+"_A_enb(0)),\n"
-                        portlist += "        addrb     => ("
-                        portlist += mem+"_AV_readaddr(4),"
-                        portlist += mem+"_AV_readaddr(3),"
-                        portlist += mem+"_AV_readaddr(2),"
-                        portlist += mem+"_AV_readaddr(1),"
-                        portlist += mem+"_AV_readaddr(0)),\n"
-                        portlist += "        doutb     => "+mem+"_V_datatmp,\n"
-                        portlist += "        enb_nent  => "+mem+"_enb_nent,\n"
-                        portlist += "        addr_nent  => "+mem+"_V_addr_nent,\n"
-                        portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
-                        portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
+                ncopy = 5
+                if "VMSME" in mem:
+                    ncopy = 4
+                portlist += "        enb       => ("
+                for i in reversed(range(0, ncopy)) : 
+                    if i != 0 :
+                        portlist += mem+"_A_enb("+str(i)+"),"
                     else:
-                        portlist += "        enb       => ("
-                        portlist += mem+"_A_enb(3),"
-                        portlist += mem+"_A_enb(2),"
-                        portlist += mem+"_A_enb(1),"
-                        portlist += mem+"_A_enb(0)),\n"
-                        portlist += "        addrb     => ("
-                        portlist += mem+"_AV_readaddr(3),"
-                        portlist += mem+"_AV_readaddr(2),"
-                        portlist += mem+"_AV_readaddr(1),"
-                        portlist += mem+"_AV_readaddr(0)),\n"
-                        portlist += "        doutb     => "+mem+"_V_datatmp,\n"
-                        portlist += "        enb_nent  => "+mem+"_enb_nent,\n"
-                        portlist += "        addr_nent  => "+mem+"_V_addr_nent,\n"
-                        portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
-                        portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
-                else:
-                    portlist += "        nent_o    => "+mem+"_AV_dout_nent,\n"
+                        portlist += mem+"_A_enb("+str(i)+")),\n"
+                portlist += "        addrb     => ("
+                for i in reversed(range(0, ncopy)) : 
+                    if i !=0 :
+                        portlist += mem+"_AV_readaddr("+str(i)+"),"
+                    else:
+                        portlist += mem+"_AV_readaddr("+str(i)+")),\n"
+                portlist += "        doutb     => "+mem+"_V_datatmp,\n"
+                portlist += "        enb_nent  => "+mem+"_enb_nent,\n"
+                portlist += "        addr_nent  => "+mem+"_V_addr_nent,\n"
+                portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
+                portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
             else:
                 portlist += "        nent_o    => "+mem+"_AV_dout_nent,\n"
         else:
             portlist += "        nent_o    => open,\n"
 
-    #    enum_type = "enum_"+mtypeB
-    #    genName = mtypeB+"_loop"
-    #    mem_str += "  "+genName+" : for var in "+enum_type+" generate\n"
-    #    mem_str += "  begin\n\n"
         if memList[0].is_binned:
             vmstubwidth = "16"
             if "17" in mtypeB:
@@ -580,25 +552,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                     mem_str += "        dataout"+str(i)+" => "+mem+"_AV_dout_mask("+str(i)+")\n"
             mem_str += "      );\n\n"
             mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
-
-            #if module == "TP_" :
-            #    mem_str += "      port map (\n"
-            #    mem_str += "        datain => "+mem+"_V_masktmp,\n"
-            #    mem_str += "        dataout0 => "+mem+"_AV_dout_mask(0),\n"
-            #    mem_str += "        dataout1 => "+mem+"_AV_dout_mask(1)\n"
-            #    mem_str += "      );\n\n"
-            #    mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
-            #elif module == "MP_" :
-            #    mem_str += "      port map (\n"
-            #    mem_str += "        datain => "+mem+"_V_masktmp,\n"
-            #    mem_str += "        dataout0 => "+mem+"_AV_dout_mask(0),\n"
-            #    mem_str += "        dataout1 => "+mem+"_AV_dout_mask(1),\n"
-            #    mem_str += "        dataout2 => "+mem+"_AV_dout_mask(2),\n"
-            #    mem_str += "        dataout3 => "+mem+"_AV_dout_mask(3)\n"
-            #    mem_str += "      );\n\n"
-            #    mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
-            #else:
-            #    mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
         else:
             mem_str += "    "+mem+" : entity work.tf_mem\n"        
         mem_str += "      generic map (\n"+parameterlist.rstrip(",\n")+"\n      )\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -630,7 +630,10 @@ def writeControlSignals_interface(initial_proc, final_proc, notfinal_procs, dela
     string_ctrl_signals += "    reset      : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_start  : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_bx_in : in std_logic_vector(2 downto 0);\n"
-    string_ctrl_signals += "    "+final_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
+    if delay > 0:
+      string_ctrl_signals += "    "+final_proc+"_bx_out_0 : out std_logic_vector(2 downto 0);\n"
+    else:
+      string_ctrl_signals += "    "+final_proc+"_bx_out : out std_logic_vector(2 downto 0);\n"
     string_ctrl_signals += "    "+final_proc+"_bx_out_vld : out std_logic;\n"
     string_ctrl_signals += "    "+final_proc+"_done   : out std_logic;\n"
     if final_proc.startswith("FT"):
@@ -1201,7 +1204,7 @@ def writeProcBXPort(modName,isInput,isInitial,delay):
     elif isInput and not isInitial:
         bx_str += "      bx_V          => "+modName+"_bx_out,\n"
     elif not isInput:
-        if modName == "FT" or delay==0:
+        if delay==0:
             bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
             bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
         else:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -845,8 +845,9 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
     string_constants += "  constant inputFileNameEnding".ljust(str_len) + ": string := \"_" + sector + ".dat\"; -- " + sector + " specifies the nonant/sector the testvectors represent\n"
     string_constants += "  constant outputFileNameEnding".ljust(str_len) + ": string := \".txt\";\n"
     string_constants += "  constant debugFileNameEnding".ljust(str_len) + ": string := \".debug.txt\";\n\n"
+    #FIXME dummy signals for AS_36 outputs are unneeded when VMSMERouter added to wiring files
     string_constants += "  signal dummy : STD_LOGIC := '0';\n\n -- dummy tb signal for inputs into sectorproc\n"
-    string_constants += "  signal dummyaddr : t_as_36_addr := (others => '0');\n\n -- dummy tb signal for inputs into sectorproc"
+    string_constants += "  signal dummy_AS_36_addr : t_as_36_addr := (others => '0');\n\n -- dummy tb signal for inputs into sectorproc"
 
     return string_constants
 
@@ -1044,7 +1045,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
             mem = memMod.inst
             if split and ("AS" in mtypeB and "n1" in mem):
                     string_output += ("        "+mem+"_enb").ljust(str_len) + "=> dummy,\n"
-                    string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> dummyaddr,\n"
+                    string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> dummy_AS_36_addr,\n"
                     string_output += ("        "+mem+"_V_dout").ljust(str_len) + "=> open,\n"
                     string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> open,\n"
             if memInfo.is_initial:

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -270,7 +270,7 @@ def writeMemoryUtil(memDict, memInfoDict):
             tName = "t_"+mtypeB+"_NENT"
             if combined:
               if  "VMSME" in tName :
-                ss += "  subtype "+tName+" is std_logic_vector(31 downto 0);\n"
+                ss += "  subtype "+tName+" is std_logic_vector(63 downto 0);\n"
                 tName = "t_"+mtypeB+"_NENTADDR"
                 ss += "  subtype "+tName+" is std_logic_vector(4 downto 0);\n"
               else:
@@ -417,18 +417,19 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                             wirelist += "  signal "+mem+"_V_masktmp : "
                             wirelist += "std_logic_vector(64*2-1 downto 0);\n"
                         else:
-                            wirelist += "  signal "+mem+"_enb_nentA : "
+                            wirelist += "  signal "+mem+"_enb_nent         : "
                             wirelist += "t_"+mtypeB+"_1b;\n"
-                            wirelist += "  signal "+mem+"_enb_nentB : "
-                            wirelist += "t_"+mtypeB+"_1b;\n"
-                            wirelist += "  signal "+mem+"_V_addr_nentA : "
+                            wirelist += "  signal "+mem+"_V_addr_nent   : "
                             wirelist += "t_"+mtypeB+"_NENTADDR;\n"
-                            wirelist += "  signal "+mem+"_V_addr_nentB : "
-                            wirelist += "t_"+mtypeB+"_NENTADDR;\n"
-                            wirelist += "  signal "+mem+"_V_dout_nentA : "
-                            wirelist += "t_"+mtypeB+"_NENT;\n"
-                            wirelist += "  signal "+mem+"_V_dout_nentB : "
-                            wirelist += "t_"+mtypeB+"_NENT;\n"
+                            wirelist += "  signal "+mem+"_AV_dout_nent : "
+                            wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
+                            wirelist += "  signal "+mem+"_V_datatmp : "
+                            if "16" in mtypeB :
+                                wirelist += "std_logic_vector(63 downto 0);\n"
+                            else:
+                                wirelist += "std_logic_vector(67 downto 0);\n"
+                            wirelist += "  signal "+mem+"_V_masktmp : "
+                            wirelist += "std_logic_vector(64*4-1 downto 0);\n"
                     else:
                         wirelist += "  signal "+mem+"_AAV_dout_nent : "
                         wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
@@ -457,9 +458,17 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             parameterlist += "        NUM_PHI_BINS    => 8,\n"
             parameterlist += "        NUM_RZ_BINS     => 8,\n"
             parameterlist += "        NUM_COPY        => 5\n"
+        if "VMSME_L" in memList[0].inst: # VMSME memories have 16 bins in the disks
+            parameterlist += "        ADDR_WIDTH      => 4,\n"
+            parameterlist += "        NUM_PHI_BINS    => 8,\n"
+            parameterlist += "        NUM_RZ_BINS     => 8,\n"
+            parameterlist += "        NUM_COPY        => 4\n"
         if "VMSME_D" in memList[0].inst: # VMSME memories have 16 bins in the disks
-            parameterlist += "        NUM_MEM_BINS    => 16,\n"
-            parameterlist += "        NUM_ENTRIES_PER_MEM_BINS => 8,\n"
+            parameterlist += "        ADDR_WIDTH      => 4,\n"
+            parameterlist += "        NUM_PHI_BINS    => 8,\n"
+            parameterlist += "        NUM_RZ_BINS     => 16,\n"
+            parameterlist += "        NUM_COPY        => 4\n"
+
             #FIXME implement delay for disks
         # Write ports
         portlist += "        clka      => clk,\n"
@@ -501,13 +510,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         portlist += "        clkb      => clk,\n"
         portlist += "        rstb      => '0',\n"
         portlist += "        regceb    => '1',\n"
-        if combined :
-            for inst in range(0,nmem) :
-                if "VMSME" in mem :
-                    portlist += "        enb"+str(inst)+"       => "+mem+"_A_enb("+str(inst)+"),\n"
-                    portlist += "        addrb"+str(inst)+"     => "+mem+"_AV_readaddr("+str(inst)+"),\n"
-                    portlist += "        doutb"+str(inst)+"     => "+mem+"_AV_dout("+str(inst)+"),\n"
-        else:
+        if not combined :
             portlist += "        enb       => "+mem+"_enb,\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"
             portlist += "        doutb     => "+mem+"_V_dout,\n"
@@ -517,7 +520,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             if memList[0].is_binned:
                 if combined:
                     if "VMSTE" in mtypeB :
-                        #portlist += "        nent_o    => "+mem+"_AAV_dout_nent,\n"
                         portlist += "        enb       => ("
                         portlist += mem+"_A_enb(4),"
                         portlist += mem+"_A_enb(3),"
@@ -536,13 +538,21 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                         portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
                         portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
                     else:
-                        portlist += "        mask_o    => "+mem+"_AV_dout_mask,\n"
-                        portlist += "        enb_nentA  => "+mem+"_enb_nentA,\n"
-                        portlist += "        enb_nentB  => "+mem+"_enb_nentB,\n"
-                        portlist += "        addr_nentA  => "+mem+"_V_addr_nentA,\n"
-                        portlist += "        addr_nentB  => "+mem+"_V_addr_nentB,\n"
-                        portlist += "        dout_nentA    => "+mem+"_V_dout_nentA,\n"
-                        portlist += "        dout_nentB    => "+mem+"_V_dout_nentB,\n"
+                        portlist += "        enb       => ("
+                        portlist += mem+"_A_enb(3),"
+                        portlist += mem+"_A_enb(2),"
+                        portlist += mem+"_A_enb(1),"
+                        portlist += mem+"_A_enb(0)),\n"
+                        portlist += "        addrb     => ("
+                        portlist += mem+"_AV_readaddr(3),"
+                        portlist += mem+"_AV_readaddr(2),"
+                        portlist += mem+"_AV_readaddr(1),"
+                        portlist += mem+"_AV_readaddr(0)),\n"
+                        portlist += "        doutb     => "+mem+"_V_datatmp,\n"
+                        portlist += "        enb_nent  => "+mem+"_enb_nent,\n"
+                        portlist += "        addr_nent  => "+mem+"_V_addr_nent,\n"
+                        portlist += "        dout_nent  => "+mem+"_AV_dout_nent,\n"
+                        portlist += "        mask_o    => "+mem+"_V_masktmp,\n"
                 else:
                     portlist += "        nent_o    => "+mem+"_AV_dout_nent,\n"
             else:
@@ -557,7 +567,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
         if memList[0].is_binned:
             module =  memList[0].downstreams[0].inst[0:3]
             if module == "TP_" :
-                mem_str += "    "+mem+"_dataformat : entity work.vmstub16dout5\n"
+                if "16" in mtypeB :
+                    mem_str += "    "+mem+"_dataformat : entity work.vmstub16dout5\n"
+                else: 
+                    mem_str += "    "+mem+"_dataformat : entity work.vmstub17dout5\n"
                 mem_str += "      port map (\n"
                 mem_str += "        datain => "+mem+"_V_datatmp,\n"
                 mem_str += "        dataout0 => "+mem+"_AV_dout(0),\n"
@@ -566,7 +579,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 mem_str += "        dataout3 => "+mem+"_AV_dout(3),\n"
                 mem_str += "        dataout4 => "+mem+"_AV_dout(4)\n"
                 mem_str += "      );\n\n"
-                mem_str += "    "+mem+"_maskformat : entity work.vmstub16mask\n"
+                mem_str += "    "+mem+"_maskformat : entity work.vmstub2mask\n"
                 mem_str += "      port map (\n"
                 mem_str += "        datain => "+mem+"_V_masktmp,\n"
                 mem_str += "        dataout0 => "+mem+"_AV_dout_mask(0),\n"
@@ -574,7 +587,26 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 mem_str += "      );\n\n"
                 mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
             elif module == "MP_" :
-                mem_str += "    "+mem+" : entity work.tf_mem_bin_cm4\n"
+                if "16" in mtypeB :
+                    mem_str += "    "+mem+"_dataformat : entity work.vmstub16dout4\n"
+                else: 
+                    mem_str += "    "+mem+"_dataformat : entity work.vmstub17dout4\n"
+                mem_str += "      port map (\n"
+                mem_str += "        datain => "+mem+"_V_datatmp,\n"
+                mem_str += "        dataout0 => "+mem+"_AV_dout(0),\n"
+                mem_str += "        dataout1 => "+mem+"_AV_dout(1),\n"
+                mem_str += "        dataout2 => "+mem+"_AV_dout(2),\n"
+                mem_str += "        dataout3 => "+mem+"_AV_dout(3)\n"
+                mem_str += "      );\n\n"
+                mem_str += "    "+mem+"_maskformat : entity work.vmstub4mask\n"
+                mem_str += "      port map (\n"
+                mem_str += "        datain => "+mem+"_V_masktmp,\n"
+                mem_str += "        dataout0 => "+mem+"_AV_dout_mask(0),\n"
+                mem_str += "        dataout1 => "+mem+"_AV_dout_mask(1),\n"
+                mem_str += "        dataout2 => "+mem+"_AV_dout_mask(2),\n"
+                mem_str += "        dataout3 => "+mem+"_AV_dout_mask(3)\n"
+                mem_str += "      );\n\n"
+                mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
             else:
                 mem_str += "    "+mem+" : entity work.tf_mem_bin\n"
         else:
@@ -1246,11 +1278,10 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
     if mem.has_numEntries_out and portindex == 0:
         #First branch is for combined modules
         if combined:
-            if mem.mtype == "VMStubsTEOuter" :
-                if "VMSTE" in mem.mtype_short() :
-                    string_mem_ports += "      "+argname+"_nentries_V_ce0 => "+mem.mtype_short()+"_"+mem.var()+"_enb_nent,\n"
-                    string_mem_ports += "      "+argname+"_nentries_V_address0 => "+mem.mtype_short()+"_"+mem.var()+"_V_addr_nent,\n"
-                    string_mem_ports += "      "+argname+"_nentries_V_q0 => "+mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent,\n"
+            if mem.mtype == "VMStubsTEOuter" or mem.mtype == "VMStubsME" :
+                string_mem_ports += "      "+argname+"_nentries_V_ce0 => "+mem.mtype_short()+"_"+mem.var()+"_enb_nent,\n"
+                string_mem_ports += "      "+argname+"_nentries_V_address0 => "+mem.mtype_short()+"_"+mem.var()+"_V_addr_nent,\n"
+                string_mem_ports += "      "+argname+"_nentries_V_q0 => "+mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent,\n"
                 for i in range(0,2**mem.bxbitwidth):
                     if mem.is_binned:
                         for j in range(0,8):
@@ -1260,14 +1291,6 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0,combined=False):
                                     string_mem_ports += ", "
                                 string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AV_dout_mask("+str(i)+")("+str(j+(7-k)*8)+")"
                             string_mem_ports += "),\n"
-                        if "VMSTE" not in mem.mtype_short() :
-                            for j in range(0,8):
-                                string_mem_ports += "      "+argname+"_nentries8_"+str(i)+"_V_"+str(j)+"     => ("
-                                for k in range(0, 8) :
-                                    if k != 0 :
-                                        string_mem_ports += ", "
-                                        string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AAV_dout_nent("+str(i)+")("+str(j+(7-k)*8)+")"
-                                string_mem_ports += "),\n"
                     else:
                         string_mem_ports += "      "+argname+"_nentries_"+str(i)+"_V               => "
                         string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_AV_dout_nent("+str(i)+"),\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -449,7 +449,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
             wirelist += "  signal "+mem+"_din_delay         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
-            if ((interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB)) and "VMSME" not in mtypeB:
+            if ((interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB)):
                 wirelist += "  signal "+mem+"_wea          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_writeaddr   : "
@@ -693,7 +693,7 @@ def writeMemoryLHSPorts_interface(memList, mtypeB, extraports=False):
     # Top-level interface: input memories' ports.
     """
 
-    if (extraports or "VMSME" in mtypeB):
+    if (extraports):
         direction = "out" # carry debug info to test-bench
     else:
         direction = "in"
@@ -754,7 +754,6 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo, memDict):
           disk="DISK"
 
       if "VMSME" in mtypeB:
-          
           string_output_mems += "    "+mem+"_A_enb          : in t_"+mtypeB+"_A1b;\n"
           string_output_mems += "    "+mem+"_AV_readaddr    : in t_"+mtypeB+"_AADDR"+disk+";\n"
           string_output_mems += "    "+mem+"_AV_dout        : out t_"+mtypeB+"_ADATA;\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -858,6 +858,8 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector):
     string_constants += "  constant inputFileNameEnding".ljust(str_len) + ": string := \"_" + sector + ".dat\"; -- " + sector + " specifies the nonant/sector the testvectors represent\n"
     string_constants += "  constant outputFileNameEnding".ljust(str_len) + ": string := \".txt\";\n"
     string_constants += "  constant debugFileNameEnding".ljust(str_len) + ": string := \".debug.txt\";\n\n"
+    string_constants += "  signal dummy : STD_LOGIC := '0';\n\n -- dummy tb signal for inputs into sectorproc"
+    string_constants += "  signal dummyaddr : t_as_36_addr := (others => '0');\n\n -- dummy tb signal for inputs into sectorproc"
 
     return string_constants
 
@@ -1054,8 +1056,8 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
         for memMod in memList:
             mem = memMod.inst
             if split and ("AS" in mtypeB and "n1" in mem):
-                    string_output += ("        "+mem+"_enb").ljust(str_len) + "=> open,\n"
-                    string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> open,\n"
+                    string_output += ("        "+mem+"_enb").ljust(str_len) + "=> dummy,\n"
+                    string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> dummyaddr,\n"
                     string_output += ("        "+mem+"_V_dout").ljust(str_len) + "=> open,\n"
                     string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> open,\n"
             if memInfo.is_initial:
@@ -1320,11 +1322,16 @@ def writeProcMemoryLHSPorts(argname,mem,split = False):
     """
 
     string_mem_ports = ""
-    if ("TPROJ" in mem.inst or "VMSME" in mem.inst) and split: #set TPROJ and VMSME to open for a split-FPGA project
+    if ("TPROJ" in mem.inst) and split: #set TPROJ and VMSME to open for a split-FPGA project
           string_mem_ports += "      "+argname+"_dataarray_data_V_ce0       => open,\n"
           string_mem_ports += "      "+argname+"_dataarray_data_V_we0       => open,\n"
           string_mem_ports += "      "+argname+"_dataarray_data_V_address0  => open,\n"
           string_mem_ports += "      "+argname+"_dataarray_data_V_d0        => open,\n"
+    elif ("VMSME" in mem.inst and split):
+        string_mem_ports += "      "+argname+"_dataarray_0_data_V_ce0       => open,\n"
+        string_mem_ports += "      "+argname+"_dataarray_0_data_V_we0       => open,\n"
+        string_mem_ports += "      "+argname+"_dataarray_0_data_V_address0  => open,\n"
+        string_mem_ports += "      "+argname+"_dataarray_0_data_V_d0        => open,\n"
     elif "memoriesTEO" in argname or "memoryME" in argname :
         string_mem_ports += "      "+argname+"_dataarray_0_data_V_ce0       => open,\n"
         string_mem_ports += "      "+argname+"_dataarray_0_data_V_we0       => "

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -290,8 +290,12 @@ def writeMemoryUtil(memDict, memInfoDict):
                 ss += "  subtype "+tName+" is std_logic_vector("+str(ncopy-1)+" downto 0);\n" 
                 tName = "t_"+mtypeB+"_ADDR"
                 ss += "  subtype "+tName+" is std_logic_vector("+str(9+memInfo.bxbitwidth)+" downto 0);\n" 
+                tName = "t_"+mtypeB+"_ADDRDISK"
+                ss += "  subtype "+tName+" is std_logic_vector("+str(10+memInfo.bxbitwidth)+" downto 0);\n" 
                 tName = "t_"+mtypeB+"_AADDR"
                 ss += "  subtype "+tName+" is t_arr"+str(ncopy)+"_"+str(10+memInfo.bxbitwidth)+"b;\n"
+                tName = "t_"+mtypeB+"_AADDRDISK"
+                ss += "  subtype "+tName+" is t_arr"+str(ncopy)+"_"+str(11+memInfo.bxbitwidth)+"b;\n"
                 tName = "t_"+mtypeB+"_DATA"
                 ss += "  subtype "+tName+" is std_logic_vector("+str(bitwidth-1)+" downto 0);\n"  
                 tName = "t_"+mtypeB+"_ADATA"
@@ -317,12 +321,26 @@ def writeMemoryUtil(memDict, memInfoDict):
                 if "VMSTE" in mtypeB :
                     nentaddrbits = "3"
                 ss += "  subtype "+tName+" is std_logic_vector("+nentaddrbits+" downto 0);\n"
+                tName = "t_"+mtypeB+"_NENTADDRDISK"
+                nentaddrbits = "5"
+                if "VMSTE" in mtypeB :
+                    nentaddrbits = "4"
+                ss += "  subtype "+tName+" is std_logic_vector("+nentaddrbits+" downto 0);\n"
             else:
                 ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
             if memInfo.is_binned:
                 varStr = "_64_1b"
                 tName = "t_"+mtypeB+"_MASK"
                 ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
+                tName = "t_"+mtypeB+"_MASK_"+str(num_pages)
+#                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
+                ss += "  subtype "+tName+" is std_logic_vector("+str(num_pages)+"*64-1 downto 0);\n"
+                varStr = "_128_1b"
+                tName = "t_"+mtypeB+"_MASKDISK"
+                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
+                tName = "t_"+mtypeB+"_MASKDISK_"+str(num_pages)
+#                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
+                ss += "  subtype "+tName+" is std_logic_vector("+str(num_pages)+"*128-1 downto 0);\n"
                 vmstubwidth = 17
                 if "16" in mtypeB:
                     vmstubwidth = 16
@@ -403,10 +421,13 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
 
         nmem = 0
 
+        mem=memmod.inst
+
+        disk = ""
         if memInfo.is_binned:
             nmem = getVMStubNCopy(memmod)
-
-        mem=memmod.inst
+            if "_D" in mem:
+                disk="DISK"
 
         parameterlist = ""
         portlist = ""
@@ -419,20 +440,20 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             wirelist += "  signal "+mem+"_wea_delay_0          : "
             wirelist += "t_"+mtypeB+"_1b;\n"
             wirelist += "  signal "+mem+"_writeaddr_delay_0   : "
-            wirelist += "t_"+mtypeB+"_ADDR;\n"
+            wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
             wirelist += "  signal "+mem+"_din_delay_0         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
             wirelist += "  signal "+mem+"_wea_delay          : "
             wirelist += "t_"+mtypeB+"_1b;\n"
             wirelist += "  signal "+mem+"_writeaddr_delay   : "
-            wirelist += "t_"+mtypeB+"_ADDR;\n"
+            wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
             wirelist += "  signal "+mem+"_din_delay         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
             if (interface != -1 and not extraports) or (interface == 1 and extraports and "VMSME" not in mtypeB):
                 wirelist += "  signal "+mem+"_wea          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_writeaddr   : "
-                wirelist += "t_"+mtypeB+"_ADDR;\n"
+                wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
                 wirelist += "  signal "+mem+"_din         : "
                 wirelist += "t_"+mtypeB+"_DATA;\n"
     
@@ -441,14 +462,14 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 wirelist += "  signal "+mem+"_A_enb         : "
                 wirelist += "t_"+mtypeB+"_A1b;\n"
                 wirelist += "  signal "+mem+"_AV_readaddr   : "
-                wirelist += "t_"+mtypeB+"_AADDR;\n"
+                wirelist += "t_"+mtypeB+"_AADDR"+disk+";\n"
                 wirelist += "  signal "+mem+"_AV_dout       : "
                 wirelist += "t_"+mtypeB+"_ADATA;\n"
             else:
                 wirelist += "  signal "+mem+"_enb          : "
                 wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_V_readaddr    : "
-                wirelist += "t_"+mtypeB+"_ADDR;\n"
+                wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
                 wirelist += "  signal "+mem+"_V_dout        : "
                 wirelist += "t_"+mtypeB+"_DATA;\n" 
 
@@ -457,31 +478,37 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                     #vmstubwidth = 17
                     #if "16" in mtypeB :
                     #    vmstubwidth = 16 
+                    disk=""
+                    if "_D" in mem:
+                        disk="DISK"
                     wirelist += "  signal "+mem+"_AV_dout_mask : "
-                    wirelist += "t_"+mtypeB+"_MASK; -- (#page)(#bin)\n"  
+                    wirelist += "t_"+mtypeB+"_MASK"+disk+"; -- (#page)(#bin)\n"  
                     wirelist += "  signal "+mem+"_enb_nent         : "
                     wirelist += "t_"+mtypeB+"_1b;\n"
                     wirelist += "  signal "+mem+"_V_addr_nent   : "
-                    wirelist += "t_"+mtypeB+"_NENTADDR;\n"
+                    wirelist += "t_"+mtypeB+"_NENTADDR"+disk+";\n"
                     wirelist += "  signal "+mem+"_AV_dout_nent : "
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
                     wirelist += "  signal "+mem+"_V_datatmp : "
                     wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
                     #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
                     wirelist += "  signal "+mem+"_V_masktmp : "
-                    wirelist += "t_"+mtypeB+"_MASK_"+str(num_pages)+";\n"
+                    wirelist += "t_"+mtypeB+"_MASK"+disk+"_"+str(num_pages)+";\n"
                     #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
                 else:
                     wirelist += "  signal "+mem+"_AV_dout_nent  : "
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)\n"
         else :
-          if memInfo.is_binned:
-            wirelist += "  signal "+mem+"_V_datatmp : "
-            wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
-            #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
-            wirelist += "  signal "+mem+"_V_masktmp : "
-            wirelist += "t_"+mtypeB+"_MASK_"+str(num_pages)+";\n"
-            #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
+            if memInfo.is_binned:
+                disk=""
+                if "_D" in mem:
+                    disk="DISK"
+                wirelist += "  signal "+mem+"_V_datatmp : "
+                wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
+                #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
+                wirelist += "  signal "+mem+"_V_masktmp : "
+                wirelist += "t_"+mtypeB+"_MASK"+disk+"_"+str(num_pages)+";\n"
+                #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
 
         # Write parameters
         parameterlist += "        RAM_WIDTH       => "+bitwidth+",\n"
@@ -495,24 +522,35 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             #enable to use non-default delay value
             delay_parameterlist +="        NUM_PAGES       => "+str(num_pages)+",\n"
             if memInfo.is_binned:
-                delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+"*PAGE_LENGTH_CM,\n"
+                disk=""
+                if "_D" in mem:
+                    disk = "*2"
+                delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+disk+"*PAGE_LENGTH_CM,\n"
             delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
 
-        if "VMSTE" in memList[0].inst: 
+        ncopy = getVMStubNCopy(memmod);
+
+
+        if "VMSTE_L" in mem: 
             parameterlist += "        ADDR_WIDTH      => 4,\n"
             parameterlist += "        NUM_PHI_BINS    => 8,\n"
             parameterlist += "        NUM_RZ_BINS     => 8,\n"
-            parameterlist += "        NUM_COPY        => 5\n"
-        if "VMSME_L" in memList[0].inst: # VMSME memories have 16 bins in the disks
-            parameterlist += "        ADDR_WIDTH      => 4,\n"
-            parameterlist += "        NUM_PHI_BINS    => 8,\n"
-            parameterlist += "        NUM_RZ_BINS     => 8,\n"
-            parameterlist += "        NUM_COPY        => 4\n"
-        if "VMSME_D" in memList[0].inst: # VMSME memories have 16 bins in the disks
+            parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
+        if "VMSTE_D" in mem: 
             parameterlist += "        ADDR_WIDTH      => 4,\n"
             parameterlist += "        NUM_PHI_BINS    => 8,\n"
             parameterlist += "        NUM_RZ_BINS     => 16,\n"
-            parameterlist += "        NUM_COPY        => 4\n"
+            parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
+        if "VMSME_L" in mem: # VMSME memories have 16 bins in the disks
+            parameterlist += "        ADDR_WIDTH      => 4,\n"
+            parameterlist += "        NUM_PHI_BINS    => 8,\n"
+            parameterlist += "        NUM_RZ_BINS     => 8,\n"
+            parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
+        if "VMSME_D" in mem: # VMSME memories have 16 bins in the disks
+            parameterlist += "        ADDR_WIDTH      => 4,\n"
+            parameterlist += "        NUM_PHI_BINS    => 8,\n"
+            parameterlist += "        NUM_RZ_BINS     => 16,\n"
+            parameterlist += "        NUM_COPY        => "+str(ncopy)+"\n"
 
             #FIXME implement delay for disks
         # Write ports
@@ -590,11 +628,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
             vmstubwidth = "16"
             if "17" in mtypeB:
                 vmstubwidth = "17"
-            ncopy = 5
-            nbx = 2
-            if "VMSME" in mem:
-                ncopy = 4
-                nbx = 4
+            nbx = 2**bxbitwidth
+            ncopy = getVMStubNCopy(memmod) 
             mem_str += "    "+mem+"_dataformat : entity work.vmstub"+vmstubwidth+"dout"+str(ncopy)+"\n"
             module =  memList[0].downstreams[0].inst[0:3]
             mem_str += "      port map (\n"
@@ -605,7 +640,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0):
                 else:
                     mem_str += "        dataout"+str(i)+" => "+mem+"_AV_dout("+str(i)+")\n"
             mem_str += "      );\n\n"
-            mem_str += "    "+mem+"_maskformat : entity work.vmstub"+str(nbx)+"mask\n"
+            disk = ""
+            if "_D" in mem:
+                disk = "DISK"
+            mem_str += "    "+mem+"_maskformat : entity work.vmstub"+str(nbx)+"mask"+disk+"\n"
             mem_str += "      port map (\n"
             mem_str += "        datain => "+mem+"_V_masktmp,\n"
             for i in range(0, nbx) :
@@ -671,8 +709,13 @@ def writeMemoryLHSPorts_interface(memList, mtypeB, extraports=False):
 
         mem = memMod.inst
 
+        disk = ""
+        if memMod.is_binned :
+            if "_D" in mem:
+                disk = "DISK"
+
         string_input_mems += "    "+mem+"_wea        : "+direction+" t_"+mtypeB+"_1b;\n"
-        string_input_mems += "    "+mem+"_writeaddr : "+direction+" t_"+mtypeB+"_ADDR;\n"
+        string_input_mems += "    "+mem+"_writeaddr : "+direction+" t_"+mtypeB+"_ADDR"+disk+";\n"
         string_input_mems += "    "+mem+"_din       : "+direction+" t_"+mtypeB+"_DATA;\n"
 
     return string_input_mems
@@ -711,28 +754,33 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo, memDict):
 
       mem = memMod.inst
 
+      disk=""
+      if "_D" in mem:
+          disk="DISK"
+
       if "VMSME" in mtypeB:
-        string_output_mems += "    "+mem+"_A_enb          : in t_"+mtypeB+"_A1b;\n"
-        string_output_mems += "    "+mem+"_AV_readaddr    : in t_"+mtypeB+"_AADDR;\n"
-        string_output_mems += "    "+mem+"_AV_dout        : out t_"+mtypeB+"_ADATA;\n"
-        string_output_mems += "    "+mem+"_AV_dout_mask        : out t_"+mtypeB+"_MASK;\n"
-        string_output_mems += "    "+mem+"_enb_nent        : out t_"+mtypeB+"_1b;\n"
-        string_output_mems += "    "+mem+"_V_addr_nent        : out t_"+mtypeB+"_NENTADDR;\n"
-        string_output_mems += "    "+mem+"_AV_dout_nent       : out t_"+mtypeB+"_NENT;\n"
+          
+          string_output_mems += "    "+mem+"_A_enb          : in t_"+mtypeB+"_A1b;\n"
+          string_output_mems += "    "+mem+"_AV_readaddr    : in t_"+mtypeB+"_AADDR"+disk+";\n"
+          string_output_mems += "    "+mem+"_AV_dout        : out t_"+mtypeB+"_ADATA;\n"
+          string_output_mems += "    "+mem+"_AV_dout_mask        : out t_"+mtypeB+"_MASK"+disk+";\n"
+          string_output_mems += "    "+mem+"_enb_nent        : out t_"+mtypeB+"_1b;\n"
+          string_output_mems += "    "+mem+"_V_addr_nent        : out t_"+mtypeB+"_NENTADDR"+disk+";\n"
+          string_output_mems += "    "+mem+"_AV_dout_nent       : out t_"+mtypeB+"_NENT;\n"
       else:
-        string_output_mems += "    "+mem+"_enb          : in t_"+mtypeB+"_1b;\n"
-        string_output_mems += "    "+mem+"_V_readaddr    : in t_"+mtypeB+"_ADDR;\n"
-        string_output_mems += "    "+mem+"_V_dout        : out t_"+mtypeB+"_DATA;\n"
-        if memInfo.has_numEntries_out:
-            num_pages = 2**bxbitwidth
-            if memInfo.is_binned:
-                string_output_mems += "    "+mem+"_AV_dout_nent : "
-                string_output_mems += "out t_"+mtypeB+"_NENT;\n"
-                string_output_mems += "    "+mem+"_AV_dout_mask : "
-                string_output_mems += "out t_"+mtypeB+"_MASK;\n"
-            else:
-                string_output_mems += "    "+mem+"_AV_dout_nent  : "
-                string_output_mems += "out t_"+mtypeB+"_NENT;\n"
+          string_output_mems += "    "+mem+"_enb          : in t_"+mtypeB+"_1b;\n"
+          string_output_mems += "    "+mem+"_V_readaddr    : in t_"+mtypeB+"_ADDR;\n"
+          string_output_mems += "    "+mem+"_V_dout        : out t_"+mtypeB+"_DATA;\n"
+          if memInfo.has_numEntries_out:
+              num_pages = 2**bxbitwidth
+              if memInfo.is_binned:
+                  string_output_mems += "    "+mem+"_AV_dout_nent : "
+                  string_output_mems += "out t_"+mtypeB+"_NENT;\n"
+                  string_output_mems += "    "+mem+"_AV_dout_mask : "
+                  string_output_mems += "out t_"+mtypeB+"_MASK;\n"
+              else:
+                  string_output_mems += "    "+mem+"_AV_dout_nent  : "
+                  string_output_mems += "out t_"+mtypeB+"_NENT;\n"
 
     return string_output_mems
 
@@ -899,16 +947,19 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
 
                 # Add nentries signal if last memory of the chain
                 if memInfo.is_binned: #FIXME including both read and write signals
+                    disk = ""
+                    if "_D" in mem:
+                        disk = "DISK"
                     string_ctrl_signals += ("  signal "+mem+"_wea").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
                     string_ctrl_signals += ("  signal "+mem+"_writeaddr").ljust(str_len)+": "
-                    string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => '0');\n"
+                    string_ctrl_signals += ("t_"+mtypeB+"_ADDR"+disk).ljust(str_len2)+":= (others => '0');\n"
                     string_ctrl_signals += ("  signal "+mem+"_din").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => '0');\n"
                     string_ctrl_signals += ("  signal "+mem+"_enb").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_A1b").ljust(str_len2)+":= (others => '0');\n"
                     string_ctrl_signals += ("  signal "+mem+"_readaddr").ljust(str_len)+": "
-                    string_ctrl_signals += ("t_"+mtypeB+"_AADDR").ljust(str_len2)+":= (others => (others => '0'));\n"
+                    string_ctrl_signals += ("t_"+mtypeB+"_AADDR"+disk).ljust(str_len2)+":= (others => (others => '0'));\n"
                     string_ctrl_signals += ("  signal "+mem+"_dout").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_ADATA").ljust(str_len2)+":= (others => (others => '0'));\n"
                     string_ctrl_signals += ("  signal "+mem+"_AAV_dout_nent").ljust(str_len)+": "
@@ -929,11 +980,15 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_proc, notfin
 
             for memMod in memList :
                 mem = memMod.inst
+                disk = ""
+                if memMod.is_binned:
+                    if "_D" in mem:
+                        disk = "DISK"
 
                 string_ctrl_signals += ("  signal "+mem+"_wea").ljust(str_len)+": "
                 string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
                 string_ctrl_signals += ("  signal "+mem+"_writeaddr").ljust(str_len)+": "
-                string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => '0');\n"
+                string_ctrl_signals += ("t_"+mtypeB+"_ADDR"+disk).ljust(str_len2)+":= (others => '0');\n"
                 string_ctrl_signals += ("  signal "+mem+"_din").ljust(str_len)+": "
                 string_ctrl_signals += ("t_"+mtypeB+"_DATA").ljust(str_len2)+":= (others => '0');\n"
 

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -333,17 +333,13 @@ def writeMemoryUtil(memDict, memInfoDict):
                 tName = "t_"+mtypeB+"_MASK"
                 ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
                 tName = "t_"+mtypeB+"_MASK_"+str(num_pages)
-#                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
                 ss += "  subtype "+tName+" is std_logic_vector("+str(num_pages)+"*64-1 downto 0);\n"
                 varStr = "_128_1b"
                 tName = "t_"+mtypeB+"_MASKDISK"
                 ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
                 tName = "t_"+mtypeB+"_MASKDISK_"+str(num_pages)
-#                ss += "  subtype "+tName+" is t_arr"+str(num_pages)+varStr+";\n"
                 ss += "  subtype "+tName+" is std_logic_vector("+str(num_pages)+"*128-1 downto 0);\n"
-                vmstubwidth = 17
-                if "16" in mtypeB:
-                    vmstubwidth = 16
+                vmstubwidth = memInfo.bitwidth
                 if "VMSTE" in mtypeB:
                     ss += "  subtype "+tName+"_2 is std_logic_vector(2*64-1 downto 0);\n" 
                     tName = "t_"+mtypeB+"_DATA"
@@ -474,9 +470,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
 
             if memInfo.has_numEntries_out:
                 if memInfo.is_binned:
-                    #vmstubwidth = 17
-                    #if "16" in mtypeB :
-                    #    vmstubwidth = 16 
                     disk=""
                     if "VMSME_D" in mem:
                         disk="DISK"
@@ -490,10 +483,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)(#bin)\n"
                     wirelist += "  signal "+mem+"_V_datatmp : "
                     wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
-                    #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
                     wirelist += "  signal "+mem+"_V_masktmp : "
                     wirelist += "t_"+mtypeB+"_MASK"+disk+"_"+str(num_pages)+";\n"
-                    #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
                 else:
                     wirelist += "  signal "+mem+"_AV_dout_nent  : "
                     wirelist += "t_"+mtypeB+"_NENT; -- (#page)\n"
@@ -504,10 +495,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
                     disk="DISK"
                 wirelist += "  signal "+mem+"_V_datatmp : "
                 wirelist += "t_"+mtypeB+"_DATA_"+str(nmem)+";\n"
-                #wirelist += "std_logic_vector("+str(nmem*vmstubwidth-1)+" downto 0);\n"
                 wirelist += "  signal "+mem+"_V_masktmp : "
                 wirelist += "t_"+mtypeB+"_MASK"+disk+"_"+str(num_pages)+";\n"
-                #wirelist += "std_logic_vector(64*"+str(num_pages)+"-1 downto 0);\n"
 
         # Write parameters
         parameterlist += "        RAM_WIDTH       => "+bitwidth+",\n"
@@ -619,9 +608,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
             portlist += "        nent_o    => open,\n"
 
         if memList[0].is_binned:
-            vmstubwidth = "16"
-            if "17" in mtypeB:
-                vmstubwidth = "17"
+            vmstubwidth = str(memInfo.bitwidth)
             nbx = 2**bxbitwidth
             ncopy = getVMStubNCopy(memmod) 
             mem_str += "    "+mem+"_dataformat : entity work.vmstub"+vmstubwidth+"dout"+str(ncopy)+"\n"

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -144,7 +144,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)            
-        if (memInfo.mtype == "AllStubs" and args.split): #for split fpga we want AS sent to second device
+        if (memInfo.mtype_long == "AllStubs" and args.split): #for split fpga we want AS sent to second device
           ASmemDict = {mtypeB : []}
           for mem in memList: 
             if "n1" in mem.inst: ASmemDict[mtypeB].append(mem)

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -47,7 +47,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports , delay, split = False):
         # FIFO memories are not instantiated in top-level (at end of chain?)
         if memInfo.isFIFO:
             continue
-        if "VMSME" in mtypeB or ("TPROJ" in mtypeB and split):
+        if ("VMSME" in mtypeB and split) or ("TPROJ" in mtypeB and split):
             continue
 
         print(mtypeB)
@@ -139,10 +139,10 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
             if memInfo.isFIFO:
                 string_output_mems += writeTrackStreamRHSPorts_interface(mtypeB, memDict)
             else:
-                if "VMSME" in mtypeB:
+                if ("VMSME" in mtypeB and args.split):
                   string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)
                 else:
-                  if "TPROJ" not in mtypeB:
+                  if ("TPROJ" not in mtypeB and  not args.split):
                     string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo,memDict)
               
         elif extraports:
@@ -290,10 +290,10 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
             if memInfo.isFIFO:
               string_final += string_tmp
             else:
-              if "VMSME" in mtypeB:
-                 string_final += writeTBMemoryWriteInstance(mtypeB, memList, proc, up_proc, memInfo.bxbitwidth, memInfo.is_binned, is_cm)
-              else:
-                string_final += writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, memInfo.bxbitwidth, memInfo.is_binned)
+#              if "VMSME" in mtypeB:
+#                 string_final += writeTBMemoryWriteInstance(mtypeB, memList, proc, up_proc, memInfo.bxbitwidth, memInfo.is_binned, is_cm)
+#              else:
+              string_final += writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, memInfo.bxbitwidth, memInfo.is_binned)
         elif not memInfo.is_initial: # intermediate memories
             if memInfo.isFIFO:
               string_intermediate += string_tmp

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -135,7 +135,9 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
             if memInfo.isFIFO:
                 string_output_mems += writeTrackStreamRHSPorts_interface(mtypeB, memDict)
             else:
-                string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo)
+                string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo,memDict)
+                if "VMSME" in mtypeB and extraports:
+                  string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)            
@@ -281,7 +283,10 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs):
             if memInfo.isFIFO:
               string_final += string_tmp
             else:
-              string_final += writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, memInfo.bxbitwidth, memInfo.is_binned)
+              if "VMSME" in mtypeB:
+                 string_final += writeTBMemoryWriteInstance(mtypeB, memList, proc, up_proc, memInfo.bxbitwidth, memInfo.is_binned, is_cm)
+              else:
+                string_final += writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, memInfo.bxbitwidth, memInfo.is_binned)
         elif not memInfo.is_initial: # intermediate memories
             if memInfo.isFIFO:
               string_intermediate += string_tmp

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -138,13 +138,13 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
             if memInfo.isFIFO:
                 string_output_mems += writeTrackStreamRHSPorts_interface(mtypeB, memDict)
             else:
-                  if not (("TPROJ" in mtypeB or "VMSME" in mtypeB) and args.split):
+                if not (("TPROJ" in mtypeB or "VMSME" in mtypeB) and args.split):
                     string_output_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo,memDict)
               
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)            
-        if ("AS_36" in mtypeB and args.split): #for split fpga we want AS sent to second device
+        if (memInfo.mtype == "AllStubs" and args.split): #for split fpga we want AS sent to second device
           ASmemDict = {mtypeB : []}
           for mem in memList: 
             if "n1" in mem.inst: ASmemDict[mtypeB].append(mem)
@@ -294,9 +294,6 @@ def writeTBMemoryWrites(memDict, memInfoDict, notfinal_procs,split):
             if memInfo.isFIFO:
               string_final += string_tmp
             else:
-#              if "VMSME" in mtypeB:
-#                 string_final += writeTBMemoryWriteInstance(mtypeB, memList, proc, up_proc, memInfo.bxbitwidth, memInfo.is_binned, is_cm)
-#              else:
               string_final += writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, memInfo.bxbitwidth, memInfo.is_binned)
         elif not memInfo.is_initial: # intermediate memories
             if memInfo.isFIFO:

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -133,11 +133,6 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
                 string_input_mems += writeDTCLinkLHSPorts_interface(mtypeB, memDict)
             else:
                 string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB)
-        if ("AS_36" in mtypeB and args.split): #for split fpga we want AS sent to second device
-          ASmemDict = {mtypeB : []}
-          for mem in memList: 
-            if "n1" in mem.inst: ASmemDict[mtypeB].append(mem)
-          string_input_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo,  ASmemDict)
         elif memInfo.is_final:
             # Output arguments
             if memInfo.isFIFO:
@@ -149,6 +144,11 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
         elif extraports:
             # Debug ports corresponding to BRAM inputs.
             string_input_mems += writeMemoryLHSPorts_interface(memList, mtypeB, extraports)            
+        if ("AS_36" in mtypeB and args.split): #for split fpga we want AS sent to second device
+          ASmemDict = {mtypeB : []}
+          for mem in memList: 
+            if "n1" in mem.inst: ASmemDict[mtypeB].append(mem)
+          string_input_mems += writeMemoryRHSPorts_interface(mtypeB, memInfo,  ASmemDict)
         
     string_topmod_interface += string_ctrl_signals
     string_topmod_interface += string_input_mems


### PR DESCRIPTION
PR (corresponding with firmware_hls [315](https://github.com/cms-L1TK/firmware-hls/pull/315) adds capability to handle new binned memory module. An additional flag is added to generator_hdl.py to enable the creation of a first half split-fpga chain. This chain is from IR to TP, and excludes the VMSME and TPROJ memories that will instead be calculated on the second device.