### PR TITLE
TrackBuilder fixes

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1202,7 +1202,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             str_ctrl_wire += writeLUTWires(argname, module, innerPS, outerPS)
             string_mem_ports += writeLUTMemPorts(argname, module)
         elif argtype.startswith("bool") and argtype.endswith("&") and argname == "done":
-            string_last_track_ports = writeLastTrackPorts(is_open = not module.is_last)
+            string_last_track_ports = writeLastTrackPorts(ftName = module.inst, is_open = not module.is_last)
         else:
             # Given argument name, search for the matched port name in the mem lists
             foundMatch = False

--- a/bodge/TF_L2L3_tb_writer.vhd.bodge
+++ b/bodge/TF_L2L3_tb_writer.vhd.bodge
@@ -10,6 +10,6 @@
     DONE => FT_DONE,
     WRITE_EN => (TW_L2L3_stream_A_write and TW_L2L3_stream_AV_din(103)),
     FULL_NEG => TW_L2L3_stream_A_full_neg,
-    DATA => TW_L2L3_stream_AV_din&BW_L2L3_L1_stream_AV_din(&BW_L2L3_L4_stream_AV_din&BW_L2L3_L5_stream_AV_din&emptyDiskStub&emptyDiskStub&emptyDiskStub&emptyDiskStub
+    DATA => TW_L2L3_stream_AV_din&BW_L2L3_L1_stream_AV_din&BW_L2L3_L4_stream_AV_din&BW_L2L3_L5_stream_AV_din&emptyDiskStub&emptyDiskStub&emptyDiskStub&emptyDiskStub
   );
 


### PR DESCRIPTION
This PR fixes issues with the "done" signal coming from the TrackBuilders. Previously, the "done" ports from multiple TrackBuilders would drive the same "last track" signals. This has been addressed so that now each TrackBuilder drives its own unique "last track" signals.

I also removed a stray parenthesis from bodge/TF_L2L3_tb_writer.vhd.bodge.

The corresponding PR in firmware-hls is https://github.com/cms-L1TK/firmware-hls/pull/319.