### PR TITLE
Timing improvements

### DIFF
--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -666,10 +666,7 @@ def writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, del
     string_ctrl_signals += "    reset      : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_start  : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_bx_in : in std_logic_vector(2 downto 0);\n"
-    if delay > 0:
-      string_ctrl_signals += "    "+final_proc_short+"_bx_out_0 : out std_logic_vector(2 downto 0);\n"
-    else:
-      string_ctrl_signals += "    "+final_proc_short+"_bx_out : out std_logic_vector(2 downto 0);\n"
+    string_ctrl_signals += "    "+final_proc_short+"_bx_out : out std_logic_vector(2 downto 0);\n"
     string_ctrl_signals += "    "+final_proc_short+"_bx_out_vld : out std_logic;\n"
     string_ctrl_signals += "    "+final_proc_short+"_done   : out std_logic;\n"
     if final_proc_short == "FT":
@@ -1030,7 +1027,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     string_fwblock_inst += "        reset".ljust(str_len) + "=> reset,\n"
     string_fwblock_inst += ("        " + initial_proc + "_start").ljust(str_len) + "=> " + initial_proc + "_start,\n"
     string_fwblock_inst += ("        " + initial_proc + "_bx_in").ljust(str_len) + "=> " + initial_proc + "_bx_in,\n"
-    string_fwblock_inst += ("        " + final_proc_short + "_bx_out_0").ljust(str_len) + "=> " + final_proc_short + "_bx_out,\n"
+    string_fwblock_inst += ("        " + final_proc_short + "_bx_out").ljust(str_len) + "=> " + final_proc_short + "_bx_out,\n"
     string_fwblock_inst += ("        " + final_proc_short + "_bx_out_vld").ljust(str_len) + "=> " + final_proc_short + "_bx_out_vld,\n"
     string_fwblock_inst += ("        " + final_proc_short + "_done").ljust(str_len) + "=> " + final_proc_short + "_done,\n"
     if final_proc_short.startswith("FT"):

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -466,6 +466,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
                 wirelist += "  signal "+mem+"_AV_dout       : "
                 wirelist += "t_"+mtypeB+"_ADATA;\n"
             else:
+                wirelist += "  signal "+mem+"_enb          : "
+                wirelist += "t_"+mtypeB+"_1b;\n"
                 wirelist += "  signal "+mem+"_V_readaddr    : "
                 wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
                 wirelist += "  signal "+mem+"_V_dout        : "
@@ -504,11 +506,10 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
         # Write parameters
         parameterlist += "        RAM_WIDTH       => "+bitwidth+",\n"
         parameterlist += "        NUM_PAGES       => "+str(num_pages)+",\n"
-        if memInfo.is_binned:
-            parameterlist += "        INIT_FILE       => \"\",\n"
-            parameterlist += "        INIT_HEX        => true,\n"
-            parameterlist += "        RAM_PERFORMANCE => \"HIGH_PERFORMANCE\",\n"
-            parameterlist += "        NAME            => \""+mem+"\",\n"
+        parameterlist += "        INIT_FILE       => \"\",\n"
+        parameterlist += "        INIT_HEX        => true,\n"
+        parameterlist += "        RAM_PERFORMANCE => \"HIGH_PERFORMANCE\",\n"
+        parameterlist += "        NAME            => \""+mem+"\",\n"
         if delay > 0:
             delay2_parameterlist +="        DELAY           => " + str(delay*2) +",\n"
             delay_parameterlist +="        DELAY           => " + str(delay) +",\n"
@@ -542,19 +543,15 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
 
             #FIXME implement delay for disks
         # Write ports
-        portlist += "        clk       => clk,\n"
+        portlist += "        clka      => clk,\n"
         if delay > 0:
             portlist += "        wea       => "+mem+"_wea_delay,\n"
             portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
             portlist += "        dina      => "+mem+"_din_delay,\n"
-            if not memInfo.is_binned:
-                portlist += "        bxa       => "+mem+"_bx,\n"
         else:
             portlist += "        wea       => "+mem+"_wea,\n"
             portlist += "        addra     => "+mem+"_writeaddr,\n"
             portlist += "        dina      => "+mem+"_din,\n"
-            if not memInfo.is_binned:
-                portlist += "        bxa       => "+memInfo.upstream_mtype_short+"_bx_out,\n"
         if delay > 0:
             delay2_portlist += "        clk      => clk,\n"
             delay2_portlist += "        reset    => reset,\n"
@@ -578,12 +575,14 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
             delay_portlist += "        dina_out      => "+mem+"_din_delay,\n"
         
 
+        portlist += "        clkb      => clk,\n"
         portlist += "        rstb      => '0',\n"
+        portlist += "        regceb    => '1',\n"
         if not memInfo.is_binned :
+            portlist += "        enb       => "+mem+"_enb,\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"
             portlist += "        doutb     => "+mem+"_V_dout,\n"
-        if memInfo.is_binned:
-            portlist += "        sync_nent => "+sync_signal+",\n"
+        portlist += "        sync_nent => "+sync_signal+",\n"
 
         if memList[0].has_numEntries_out:
             if memList[0].is_binned:
@@ -755,8 +754,7 @@ def writeMemoryRHSPorts_interface(mtypeB, memInfo, memDict):
           string_output_mems += "    "+mem+"_V_addr_nent        : out t_"+mtypeB+"_NENTADDR"+disk+";\n"
           string_output_mems += "    "+mem+"_AV_dout_nent       : out t_"+mtypeB+"_NENT;\n"
       else:
-          if not memInfo.is_binned:
-              string_output_mems += "    "+mem+"_enb          : in t_"+mtypeB+"_1b;\n"
+          string_output_mems += "    "+mem+"_enb          : in t_"+mtypeB+"_1b;\n"
           string_output_mems += "    "+mem+"_V_readaddr    : in t_"+mtypeB+"_ADDR;\n"
           string_output_mems += "    "+mem+"_V_dout        : out t_"+mtypeB+"_DATA;\n"
           if memInfo.has_numEntries_out:
@@ -962,6 +960,8 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_procs, notfi
                     string_ctrl_signals += ("  signal "+mem+"_AV_dout_mask").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_MASK").ljust(str_len2)+":= (others => (others => '0')); -- (#page)(#bin)\n"
                 else:
+                    string_ctrl_signals += ("  signal "+mem+"_enb").ljust(str_len)+": "
+                    string_ctrl_signals += ("t_"+mtypeB+"_1b").ljust(str_len2)+":= '0';\n"
                     string_ctrl_signals += ("  signal "+mem+"_readaddr").ljust(str_len)+": "
                     string_ctrl_signals += ("t_"+mtypeB+"_ADDR").ljust(str_len2)+":= (others => '0');\n"
                     string_ctrl_signals += ("  signal "+mem+"_dout").ljust(str_len)+": "
@@ -1056,6 +1056,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
         for memMod in memList:
             mem = memMod.inst
             if split and ("AS" in mtypeB and "n1" in mem):
+                    string_output += ("        "+mem+"_enb").ljust(str_len) + "=> dummy,\n"
                     string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> dummy_AS_36_addr,\n"
                     string_output += ("        "+mem+"_V_dout").ljust(str_len) + "=> open,\n"
                     string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> open,\n"
@@ -1089,6 +1090,7 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
                     string_output += ("        "+mem+"_V_addr_nent").ljust(str_len) + "=> open,\n"
                     string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> open,\n"
                 else:
+                    string_output += ("        "+mem+"_enb").ljust(str_len) + "=> "+mem+"_enb,\n"
                     string_output += ("        "+mem+"_V_readaddr").ljust(str_len) + "=> "+mem+"_readaddr,\n"
                     string_output += ("        "+mem+"_V_dout").ljust(str_len) + "=> "+mem+"_dout,\n"
                     string_output += ("        "+mem+"_AV_dout_nent").ljust(str_len) + "=> "+mem+"_AV_dout_nent,\n"
@@ -1181,10 +1183,7 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned):
         string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
         string_mem += "      ADDR".ljust(str_len)+"=> "+mem+"_readaddr,\n"
         string_mem += "      DATA".ljust(str_len)+"=> "+mem+"_dout,\n"
-        if is_binned:
-          string_mem += "      READ_EN".ljust(str_len)+"=> "+mem+"_enb,\n"
-        else:
-          string_mem += "      READ_EN".ljust(str_len)+"=> '1',\n"
+        string_mem += "      READ_EN".ljust(str_len)+"=> "+mem+"_enb,\n"
         if "VMSME" not in mem: #FIXME
           string_mem += "      NENT_ARR".ljust(str_len)+"=> "+mem+"_A" + ("A" if is_binned else "") + "V_dout_nent,\n"
         else:
@@ -1372,11 +1371,8 @@ def writeProcMemoryRHSPorts(argname,mem,portindex=0):
             string_mem_ports += mem.mtype_short() + "_" + mem.var()+"_AV_dout("+str(instance)+"),\n"
     else:
         string_mem_ports = ""
-        if mem.is_binned:
-            string_mem_ports += "      "+argname+"_dataarray_data_V_ce"+str(portindex)+"       => "
-            string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_enb,\n"
-        else:
-            string_mem_ports += "      "+argname+"_dataarray_data_V_ce"+str(portindex)+"       => open,\n"
+        string_mem_ports += "      "+argname+"_dataarray_data_V_ce"+str(portindex)+"       => "
+        string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_enb,\n"
         string_mem_ports += "      "+argname+"_dataarray_data_V_address"+str(portindex)+"  => "
         string_mem_ports += mem.mtype_short()+"_"+mem.var()+"_V_readaddr,\n"
         string_mem_ports += "      "+argname+"_dataarray_data_V_q"+str(portindex)+"        => "

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1420,6 +1420,7 @@ def writeLUTPorts(argname,lut):
 
 def writeLUTParameters(argname, lut, innerPS, outerPS):
     parameterlist = ""
+    depth = 0
     width = 0
     if "in" in argname:
         width = 1


### PR DESCRIPTION
This PR includes timing improvements that were discussed in this presentation:
https://indico.cern.ch/event/1387937/#13-timing-updates

In particular, the new unbinned memory adapted from Thomas's work is used by default, and additional shift registers have been added for some of the input signals (ap_start and bx_V) to the processing modules.

ETA: The updates to the unbinned memory module have been reverted for now. To be revisited once the outstanding dual-FPGA work is merged.