### PR TITLE
Add reset port to memory modules

### DIFF
--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -703,6 +703,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
             mem_str += "      generic map (\n"+merge_parameterlist.rstrip(",\n")+"\n      )\n"
             mem_str += "      port map (\n"+merge_portlist.rstrip(",\n")+"\n      );\n\n"
         portlist += "        clkb      => clk,\n"
+        portlist += "        rsta      => reset,\n"
         portlist += "        rstb      => '0',\n"
         portlist += "        regceb    => '1',\n"
         if not memInfo.is_binned :


### PR DESCRIPTION
Previous implementation of reset in [firmware-hls#367](https://github.com/cms-L1TK/firmware-hls/pull/367) created bug where page never updated. New implementation with fixed page bug requires a reset signal, which has been added