### PR TITLE
Fixes to allow reduced FPGA1 project to run with agreement with emulation

### DIFF
--- a/TrackletGraph.py
+++ b/TrackletGraph.py
@@ -245,8 +245,10 @@ class TrackletGraph(object):
         if (      mem.mtype == "TrackletProjections" or mem.mtype == "VMProjections"
                or mem.mtype == "CandidateMatch" or mem.mtype == "FullMatch" or mem.mtype == "VMStubsME"
                or mem.mtype == "StubPairs" or mem.mtype == "VMStubsTEInner" or mem.mtype == "VMStubsTEOuter"
-                  or mem.mtype == "InputLink" or mem.mtype == "DTCLink" or mem.mtype == "AllInnerStubs"):
+                  or mem.mtype == "DTCLink" or mem.mtype == "AllInnerStubs"):
             mem.bxbitwidth = 1
+        elif ( mem.mtype == "InputLink") :
+            mem.bxbitwidth = 2
         elif (    mem.mtype == "AllProj" 
                or mem.mtype == "AllStubs" or mem.mtype == "TrackletParameters"):
             mem.bxbitwidth = 3

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1208,7 +1208,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     str_ctrl_func = ""
     oneProcUpMem = None
     for mem in module.upstreams:
-        if mem.bxbitwidth != 1: continue
+        if mem.bxbitwidth != 1 and mem.bxbitwidth != 2: continue  #What is this doing?
         if mem.upstreams[0] is None: continue
         oneProcUpMem = mem
         break
@@ -1255,7 +1255,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
         # bunch crossing
         if argtype == "BXType":
             for mem in module.upstreams:
-                if mem.bxbitwidth != 1: continue
+                if mem.bxbitwidth != 1 and mem.bxbitwidth != 2: continue #FIXME what is this doing
                 if mem.is_initial:
                     string_bx_in += writeProcBXPort(module.inst,True,True,first_of_type,delay)
                     break

--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -271,6 +271,27 @@ def getListsOfGroupedMemories(aProcModule):
     memList = list(aProcModule.upstreams + aProcModule.downstreams)
     portList = list(aProcModule.input_port_names + aProcModule.output_port_names)
 
+    #horrible hack to fix order of modules
+    ia=-1;
+    ib=-1;
+    for mem in memList:
+        if "_BE" in mem.var() :
+            ia=memList.index(mem);
+        if "_BF" in mem.var() :
+            ib=memList.index(mem);
+    if ia != -1 and ib != -1 and ib < ia :
+        memList[ia], memList[ib] = memList[ib], memList[ia]
+
+    ia=-1;
+    ib=-1;
+    for mem in memList:
+        if "L1PHIH_BC" in mem.var() :
+            ia=memList.index(mem);
+        if "L1PHIH_BD" in mem.var() :
+            ib=memList.index(mem);
+    if ia != -1 and ib != -1 and ib < ia :
+        memList[ia], memList[ib] = memList[ib], memList[ia]
+
     # Sort the VMSME and VMSTE using portList, first by the phi region number (e.g. 2 in "vmstuboutPHIA2"), then alphabetically
     zipped_list = list(zip(memList, portList))
     zipped_list.sort(key=lambda m_p: 0 if 'vmstubout' else int("".join([i for i in m_p[1] if i.isdigit()]))) # sort by number

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -712,8 +712,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
             portlist += "        doutb     => "+mem+"_V_dout,\n"
         if "AS" in mem and "n1" in mem and split == 1:
             portlist += "        sync_nent => "+first_tp+"_start,\n"
-        elif "TPAR" in mem and split == 1:
-            portlist += "        sync_nent => TP_done,\n" 
         else:
             portlist += "        sync_nent => "+mem+"_start,\n"
         if memmod.has_numEntries_out or ("n1" in mem and split == 1):
@@ -1296,7 +1294,9 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
             string_mem += "    write"+mem+" : entity work.FileWriterFIFO\n"
             string_mem += "    generic map (\n"
             string_mem += "      FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mtypeB+"&\""+mem+"\"&outputFileNameEnding,\n"
-            string_mem += "      FIFO_WIDTH".ljust(str_len)+"=> " + str(width) + "\n"
+            string_mem += "      FIFO_WIDTH".ljust(str_len)+"=> " + str(width) + ",\n"
+            string_mem += "      BX_CNT_INIT".ljust(str_len)+"=> -1,\n"
+            string_mem += "      DONE_DELAY".ljust(str_len)+"=> 6\n"
             string_mem += "    )\n"
             string_mem += "    port map (\n"
             string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
@@ -1318,12 +1318,18 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
                 string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 1024,\n"
             if "VMSME" in mem:
                 string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
+            if "VMSTE" in mem:
+                string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -1,\n" #-1 is emperically determined to allign the FileWriter BX with the data stream
         if "MPROJ" in mem :
             string_mem += "        NUM_TPAGES".ljust(str_len)+"=> 4,\n"
             string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 64,\n"
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
         if "FM" in mem :
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
+        if "IL" in mem :
+            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -2,\n" #-2 is emperically determined to allign the FileWriter BX with the data stream
+        if "AS" in mem :
+            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -16,\n" #-10 is emperically determined to allign the FileWriter BX with the data stream
         string_mem += "        NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
         string_mem += "      )\n"
         string_mem += "      port map (\n"
@@ -1377,6 +1383,8 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned, 
             string_mem += "    write"+mem+" : entity work.FileWriterFIFO\n"
             string_mem += "    generic map (\n"
             string_mem += "      FILE_NAME".ljust(str_len)+"=> FILE_OUT_"+mtypeB+"&\""+mem+"\"&outputFileNameEnding,\n"
+            string_mem += "      BX_CNT_INIT".ljust(str_len)+"=> -1,\n"
+            string_mem += "      DONE_DELAY".ljust(str_len)+"=> 5,\n"
             string_mem += "      FIFO_WIDTH".ljust(str_len)+"=> " + str(width) + "\n"
             string_mem += "    )\n"
             string_mem += "    port map (\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1326,7 +1326,7 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
         if "FM" in mem :
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
-        if "IL" in mem :
+        if "IL_" in mem :
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -2,\n" #-2 is emperically determined to allign the FileWriter BX with the data stream
         if "AS" in mem :
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -16,\n" #-10 is emperically determined to allign the FileWriter BX with the data stream

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -1319,7 +1319,7 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
             if "VMSME" in mem:
                 string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
             if "VMSTE" in mem:
-                string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -1,\n" #-1 is emperically determined to allign the FileWriter BX with the data stream
+                string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -17,\n" #-17 is emperically determined to allign the FileWriter BX with the data stream
         if "MPROJ" in mem :
             string_mem += "        NUM_TPAGES".ljust(str_len)+"=> 4,\n"
             string_mem += "        PAGE_LENGTH".ljust(str_len)+"=> 64,\n"
@@ -1327,9 +1327,9 @@ def writeTBMemoryWriteInstance(mtypeB, memList, proc, proc_up, bxbitwidth, is_bi
         if "FM" in mem :
             string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -21,\n" #-21 is emperically determined to allign the FileWriter BX with the data stream
         if "IL_" in mem :
-            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -2,\n" #-2 is emperically determined to allign the FileWriter BX with the data stream
+            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -8,\n" #-8 is emperically determined to allign the FileWriter BX with the data stream
         if "AS" in mem :
-            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -16,\n" #-10 is emperically determined to allign the FileWriter BX with the data stream
+            string_mem += "        CLK_CNT_INIT".ljust(str_len)+"=> -17,\n" #-17 is emperically determined to allign the FileWriter BX with the data stream changed for FPGA1 project
         string_mem += "        NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
         string_mem += "      )\n"
         string_mem += "      port map (\n"


### PR DESCRIPTION

 This PR consists of a set of updates to both project_generation_scripts and firmware_hls to solve several disagreements between the reduced FPGA1 project and the CMSSW C++ emulation. Many of the fixes here should be considered "patches" - e.g. the filewriting should be moved into the memory modules to make sure that we accurately print the correct debug information. Now there is a fair bit of manual adjustment to get the debug printout to allign with the memory writing.

 project_generation_scripts:

  - To avoid an overwrite of the InputLink memories I changed them to use 4 pages instead of two. Could probably have used two page after adding delays in the memory writing. This is particularly a problem here as we read multiple input memories in the VMR and the last memory to be read was over written in one of the 100 events.

 - Add delay in the FileWriterFIFO modules to align debug writing with correct BX. Similarly align debug printout for VMSTE, IL, and AS

 firmware_hls:

  - Add delay in the FileWriterFIFO.vhd

  - tf_merge_streamer.vhd has some significant rewrites to process data on each BX. The logic is a bit convoluted as the bx_in_vld signal is not aligned with the change in bx. A delay of three clocks has been added to fix this. This should probably be fixed in a cleaner way.

 - Fixes to CompareMemPrintsFW.py to handle MPAR and AS memories. This could be avoided if the debug printout followed the memory writing.

 - Make the IL memory use 4 pages instead of 2.

 

