### PR TITLE
Timing improvements and preliminary support for CDCs

### DIFF
--- a/WriteHDLUtils.py
+++ b/WriteHDLUtils.py
@@ -1213,7 +1213,7 @@ def parseProcFunction(proc_name, fname_def):
     return arg_types_list, arg_names_list, templ_pars_list
 
 def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
-                              f_matchArgPortNames, first_of_type, extraports,delay,split=0):
+                              f_matchArgPortNames, first_of_type, extraports,split=0):
     ####
     # function name
 
@@ -1234,7 +1234,7 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
         oneProcUpMem = mem
         break
     ports_added = (module.mtype in writeModuleInst_generic.modules_with_ports_added)
-    ctrl_wire_inst,ctrl_func_inst = writeStartSwitchAndInternalBX(module,oneProcUpMem,extraports or ports_added,delay, first_of_type)
+    ctrl_wire_inst,ctrl_func_inst = writeStartSwitchAndInternalBX(module,oneProcUpMem,extraports or ports_added,first_of_type)
     str_ctrl_wire += ctrl_wire_inst
     str_ctrl_func += ctrl_func_inst
     writeModuleInst_generic.modules_with_ports_added.add(module.mtype)
@@ -1278,15 +1278,15 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
             for mem in module.upstreams:
                 if mem.bxbitwidth != 1 and mem.bxbitwidth != 2: continue #FIXME what is this doing
                 if mem.is_initial:
-                    string_bx_in += writeProcBXPort(module.inst,True,True,first_of_type,delay)
+                    string_bx_in += writeProcBXPort(module.inst,True,True,first_of_type)
                     break
                 else:
-                    string_bx_in += writeProcBXPort(module.inst,True,False,first_of_type,delay)
+                    string_bx_in += writeProcBXPort(module.inst,True,False,first_of_type)
                     break
         elif argtype == "BXType&" or argtype == "BXType &": # Could change this in the HLS instead
             #FIXME hack for PC and VMSMER
             if first_of_type or module.mtype_short() == "PC" or module.mtype_short() == "VMSMER" :
-                string_bx_out += writeProcBXPort(module.inst,False,False,first_of_type, delay) # output bx
+                string_bx_out += writeProcBXPort(module.inst,False,False,first_of_type) # output bx
         elif "table" in argname: # For TE
             innerPS = ("_L1" in module.inst and "_L2" in module.inst) \
                    or ("_L2" in module.inst and "_L3" in module.inst) \
@@ -1415,81 +1415,81 @@ def writeModuleInst_generic(module, hls_src_dir, f_writeTemplatePars,
     return str_ctrl_wire,module_str
 
 ################################
-def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, delay, split = 0):
+def writeModuleInstance(module, hls_src_dir, first_of_type, extraports, split = 0):
     if module.mtype == 'InputRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_IR,
                                          matchArgPortNames_IR,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'VMRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMR,
                                          matchArgPortNames_VMR,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'VMRouterCM':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMRCM,
                                          matchArgPortNames_VMRCM,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'TrackletEngine':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TE,
                                          matchArgPortNames_TE,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'TrackletProcessor':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TP,
                                          matchArgPortNames_TP,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'TrackletCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TC,
                                          matchArgPortNames_TC,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'ProjectionRouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_PR,
                                          matchArgPortNames_PR,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'MatchEngine':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_ME,
                                          matchArgPortNames_ME,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'MatchCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_MC,
                                          matchArgPortNames_MC,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'MatchProcessor':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_MP,
                                          matchArgPortNames_MP,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'FitTrack':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_FT,
                                          matchArgPortNames_FT,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'TrackBuilder':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_TB,
                                          matchArgPortNames_TB,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'PurgeDuplicate':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_PD,
                                          matchArgPortNames_PD,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'ProjectionCalculator':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_PC,
                                          matchArgPortNames_PC,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     elif module.mtype == 'VMSMERouter':
         return writeModuleInst_generic(module, hls_src_dir,
                                          writeTemplatePars_VMSMER,
                                          matchArgPortNames_VMSMER,
-                                         first_of_type, extraports, delay, split)
+                                         first_of_type, extraports, split)
     else:
         raise ValueError(module.mtype + " is unknown.")

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -417,7 +417,7 @@ def writeMemoryUtil(memDict, memInfoDict):
 
     return ss;
 
-def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, split = False, MPARdict = 0):
+def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False, MPARdict = 0):
     """
     # Declaration of memories of type "mtype" (e.g. TPROJ) & associated wires
     # Inputs:
@@ -476,24 +476,23 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
         merge_parameterlist = ""
         merge_portlist = ""
         # Write wires
-        if delay > 0:
-            wirelist += "  signal "+mem+"_start                   : "
-            wirelist += "std_logic;\n"
-            wirelist += "  signal "+mem+"_wea_delay          : "
+        wirelist += "  signal "+mem+"_start                   : "
+        wirelist += "std_logic;\n"
+        wirelist += "  signal "+mem+"_wea_delay          : "
+        wirelist += "t_"+mtypeB+"_1b;\n"
+        wirelist += "  signal "+mem+"_writeaddr_delay   : "
+        wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
+        wirelist += "  signal "+mem+"_din_delay         : "
+        wirelist += "t_"+mtypeB+"_DATA;\n"
+        if (interface != -1 and not extraports) or (split == 1 and "TPAR" in mem):
+            if "TPAR" in mem:
+                wirelist += "  signal "+mem+"_dummy   : std_logic_vector(1 downto 0);\n"
+            wirelist += "  signal "+mem+"_wea          : "
             wirelist += "t_"+mtypeB+"_1b;\n"
-            wirelist += "  signal "+mem+"_writeaddr_delay   : "
+            wirelist += "  signal "+mem+"_writeaddr   : "
             wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
-            wirelist += "  signal "+mem+"_din_delay         : "
+            wirelist += "  signal "+mem+"_din         : "
             wirelist += "t_"+mtypeB+"_DATA;\n"
-            if (interface != -1 and not extraports) or (split == 1 and "TPAR" in mem):
-                if "TPAR" in mem:
-                    wirelist += "  signal "+mem+"_dummy   : std_logic_vector(1 downto 0);\n"
-                wirelist += "  signal "+mem+"_wea          : "
-                wirelist += "t_"+mtypeB+"_1b;\n"
-                wirelist += "  signal "+mem+"_writeaddr   : "
-                wirelist += "t_"+mtypeB+"_ADDR"+disk+";\n"
-                wirelist += "  signal "+mem+"_din         : "
-                wirelist += "t_"+mtypeB+"_DATA;\n"
         if not (interface == 1 and not split == 1):
             if memInfo.is_binned :
                 wirelist += "  signal "+mem+"_A_enb         : "
@@ -590,22 +589,20 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
         else:
             parameterlist += "        FILE_WRITE            => false,\n"
 
-        if delay > 0:
-            #enable to use non-default delay value
-            if "MPROJ" in mem:
-                #special case for the merged projections
-                delay_parameterlist +="        PAGE_LENGTH       => 64,\n"
-            if "MPAR" in mem or "MPROJ" in mem:
-                #special case for the merged memories
-                delay_parameterlist +="        NUM_PAGES       => "+str(4*num_pages)+",\n"
-            else:
-                delay_parameterlist +="        NUM_PAGES       => "+str(num_pages)+",\n"
-            if memInfo.is_binned:
-                disk=""
-                if "VMSME_D" in mem:
-                    disk = "*2"
-                delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+disk+"*PAGE_LENGTH_CM,\n"
-            delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
+        if "MPROJ" in mem:
+            #special case for the merged projections
+            delay_parameterlist +="        PAGE_LENGTH       => 64,\n"
+        if "MPAR" in mem or "MPROJ" in mem:
+            #special case for the merged memories
+            delay_parameterlist +="        NUM_PAGES       => "+str(4*num_pages)+",\n"
+        else:
+            delay_parameterlist +="        NUM_PAGES       => "+str(num_pages)+",\n"
+        if memInfo.is_binned:
+            disk=""
+            if "VMSME_D" in mem:
+                disk = "*2"
+            delay_parameterlist +="        RAM_DEPTH       => "+str(num_pages)+disk+"*PAGE_LENGTH_CM,\n"
+        delay_parameterlist +="        RAM_WIDTH       => "+bitwidth+",\n"
 
         ncopy = getVMStubNCopy(memmod);
 
@@ -631,32 +628,26 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
             #FIXME implement delay for disks
         # Write ports
         portlist += "        clka      => clk,\n"
-        if delay > 0:
-            portlist += "        wea       => "+mem+"_wea_delay,\n"
-            portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
-            portlist += "        dina      => "+mem+"_din_delay,\n"
+        portlist += "        wea       => "+mem+"_wea_delay,\n"
+        portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
+        portlist += "        dina      => "+mem+"_din_delay,\n"
+        delay_portlist += "        clk      => clk,\n"
+        delay_portlist += "        reset    => reset,\n"
+        delay_portlist += "        wea       => "+mem+"_wea,\n"
+        delay_portlist += "        addra     => "+mem+"_writeaddr,\n"
+        delay_portlist += "        dina      => "+mem+"_din,\n"
+        delay_portlist += "        wea_out       => "+mem+"_wea_delay,\n"
+        delay_portlist += "        addra_out     => "+mem+"_writeaddr_delay,\n"
+        delay_portlist += "        dina_out      => "+mem+"_din_delay,\n"
+        if not memmod.is_initial:
+            previous_module = memmod.upstreams[0].mtype_short()
+            if previous_module == "VMSMER":
+                previous_module = "PC"
+            delay_portlist += "        done       => "+previous_module+"_done,\n"
+        #elif "AS_" in mem:
         else:
-            portlist += "        wea       => "+mem+"_wea,\n"
-            portlist += "        addra     => "+mem+"_writeaddr,\n"
-            portlist += "        dina      => "+mem+"_din,\n"
-        if delay > 0:
-            delay_portlist += "        clk      => clk,\n"
-            delay_portlist += "        reset    => reset,\n"
-            delay_portlist += "        wea       => "+mem+"_wea,\n"
-            delay_portlist += "        addra     => "+mem+"_writeaddr,\n"
-            delay_portlist += "        dina      => "+mem+"_din,\n"
-            delay_portlist += "        wea_out       => "+mem+"_wea_delay,\n"
-            delay_portlist += "        addra_out     => "+mem+"_writeaddr_delay,\n"
-            delay_portlist += "        dina_out      => "+mem+"_din_delay,\n"
-            if not memmod.is_initial:
-                previous_module = memmod.upstreams[0].mtype_short()
-                if previous_module == "VMSMER":
-                    previous_module = "PC"
-                delay_portlist += "        done       => "+previous_module+"_done,\n"
-            #elif "AS_" in mem:
-            else:
-                delay_portlist += "        done       => PC_start,\n"
-            delay_portlist += "        start      => "+mem+"_start,\n"
+            delay_portlist += "        done       => PC_start,\n"
+        delay_portlist += "        start      => "+mem+"_start,\n"
         # add merge_stream modules if split and TPAR or AS
         if "TPAR" in mem and split == 1:
             addrwidth = 10
@@ -780,14 +771,13 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = 0, spl
                 mem_str += "    "+mem+" : entity work.tf_mem\n"        
         mem_str += "      generic map (\n"+parameterlist.rstrip(",\n")+"\n      )\n"
         mem_str += "      port map (\n"+portlist.rstrip(",\n")+"\n      );\n\n"
-        if delay > 0:
-            mem_str += "    "+mem+"_DELAY : entity work.tf_pipeline_slr_xing\n"        
-            mem_str += "      generic map (\n"+delay_parameterlist.rstrip(",\n")+"\n      )\n"
-            mem_str += "      port map (\n"+delay_portlist.rstrip(",\n")+"\n      );\n\n"
+        mem_str += "    "+mem+"_DELAY : entity work.tf_pipeline_slr_xing\n"        
+        mem_str += "      generic map (\n"+delay_parameterlist.rstrip(",\n")+"\n      )\n"
+        mem_str += "      port map (\n"+delay_portlist.rstrip(",\n")+"\n      );\n\n"
 
     return wirelist,mem_str
 
-def writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, delay = 0, split = 0):
+def writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, split = 0):
     """
     # Top-level interface: control signals
     """
@@ -1467,7 +1457,7 @@ def writeLUTCombination(lut, argname, portlist, parameterlist):
 
     return lut_str
 
-def writeStartSwitchAndInternalBX(module,mem,extraports=False, delay = 0, first_of_type=False):
+def writeStartSwitchAndInternalBX(module,mem,extraports=False, first_of_type=False):
     """
     # Top-level: control (start/done) & Bx signals for use by given module
     # Inputs: processing module & memory that is upstream of it.
@@ -1571,7 +1561,7 @@ def writeProcControlSignalPorts(module,first_of_type):
 
     return string_ctrl_ports
 
-def writeProcBXPort(modName,isInput,isInitial,first_of_type,delay):
+def writeProcBXPort(modName,isInput,isInitial,first_of_type):
     """
     # Processing module port assignment: BX ports
     """
@@ -1585,16 +1575,12 @@ def writeProcBXPort(modName,isInput,isInitial,first_of_type,delay):
     elif isInput and not isInitial:
         bx_str = "      bx_V          => "+modName+"_bx,\n"
     if not isInput:
-        if delay==0:
-            bx_str += "      bx_o_V        => "+modName+"_bx_out,\n"
-            bx_str += "      bx_o_V_ap_vld => "+modName+"_bx_out_vld,\n"
-        else:
-            if first_of_type and not ("VMSMER" in modName or "PC" in modName):
-                bx_str += "      bx_o_V        => "+modName.split("_")[0]+"_bx_out,\n"
-                if ("TB_" in modName) or ("TP_" in modName):
-                  bx_str += "      bx_o_V_ap_vld => "+modName.split("_")[0]+"_bx_out_vld,\n"
-                else:
-                  bx_str += "      bx_o_V_ap_vld => open,\n"
+        if first_of_type and not ("VMSMER" in modName or "PC" in modName):
+            bx_str += "      bx_o_V        => "+modName.split("_")[0]+"_bx_out,\n"
+            if ("TB_" in modName) or ("TP_" in modName):
+              bx_str += "      bx_o_V_ap_vld => "+modName.split("_")[0]+"_bx_out_vld,\n"
+            else:
+              bx_str += "      bx_o_V_ap_vld => open,\n"
     return bx_str
 
 def writeProcMemoryLHSPorts(argname,mem,split = False):

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -709,7 +709,6 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
         portlist += "        clkb      => clk,\n"
         portlist += "        rsta      => reset,\n"
         portlist += "        rstb      => '0',\n"
-        portlist += "        regceb    => '1',\n"
         if not memInfo.is_binned :
             portlist += "        enb       => '1',\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -713,10 +713,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             portlist += "        enb       => '1',\n"
             portlist += "        addrb     => "+mem+"_V_readaddr,\n"
             portlist += "        doutb     => "+mem+"_V_dout,\n"
-        if "AS" in mem and "n1" in mem and split == 1:
-            portlist += "        sync_nent => "+first_tp+"_start,\n"
-        else:
-            portlist += "        sync_nent => "+mem+"_start,\n"
+        portlist += "        sync_nent => "+mem+"_start,\n"
         if memmod.has_numEntries_out or ("n1" in mem and split == 1):
             if memList[0].is_binned:
                 ncopy = getVMStubNCopy(memmod);

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -657,6 +657,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             iTC = mem.split("_")[1][-1]
             for PCGroup in MPARdict[seed]:
                 if iTC == PCGroup[0]:
+                    wirelist += "  signal TPAR"+seed+PCGroup+"_bx                      : std_logic_vector(2 downto 0);\n"
+                    wirelist += "  signal TPAR"+seed+PCGroup+"_bx_vld                  : std_logic;\n"
                     numInputs = len(PCGroup)
                     merge_parameterlist += "        RAM_WIDTH => "+str(ramwidth)+",\n"
                     merge_parameterlist += "        NUM_PAGES => "+str(numpages)+",\n"
@@ -668,8 +670,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
                     else:
                         merge_parameterlist += "        FILE_WRITE     => false,\n"
 
-                    merge_portlist += "        bx_in => TP_bx_out,\n"
-                    merge_portlist += "        bx_in_vld => TP_bx_out_vld,\n"
+                    merge_portlist += "        bx_in => TPAR"+seed+PCGroup+"_bx,\n"
+                    merge_portlist += "        bx_in_vld => TPAR"+seed+PCGroup+"_bx_vld,\n"
                     merge_portlist += "        rst => '0',\n"
                     merge_portlist += "        clk => clk,\n"
                     #This will make output for first stream_merge module (is there a less hacky way?)
@@ -684,7 +686,19 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
                     mem_str += "      generic map (\n"+merge_parameterlist.rstrip(",\n")+"\n      )\n"
                     mem_str += "      port map (\n"+merge_portlist.rstrip(",\n")+"\n      );\n\n"
 
+                    stream_delay_portlist = ""
+                    stream_delay_portlist += "        clk        => clk240,\n"
+                    stream_delay_portlist += "        reset      => reset,\n"
+                    stream_delay_portlist += "        bx_out     => TP_bx_out,\n"
+                    stream_delay_portlist += "        bx_out_vld => TP_bx_out_vld,\n"
+                    stream_delay_portlist += "        bx         => TPAR"+seed+PCGroup+"_bx,\n"
+                    stream_delay_portlist += "        bx_vld     => TPAR"+seed+PCGroup+"_bx_vld,\n"
+                    mem_str += "    TPAR"+seed+PCGroup+"_STREAM_DELAY : entity work.tf_pipeline_slr_xing\n"        
+                    mem_str += "      port map (\n"+stream_delay_portlist.rstrip(",\n")+"\n      );\n\n"
+
         elif "AS" in mem and "n1" in mem and split == 1:
+            wirelist += "  signal "+mem+"_bx                      : std_logic_vector(2 downto 0);\n"
+            wirelist += "  signal "+mem+"_bx_vld                  : std_logic;\n"
             addrwidth = 10
             ramwidth = memInfo.bitwidth
             numpages = 8
@@ -695,8 +709,8 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             merge_parameterlist += "        NUM_EXTRA_BITS => 0,\n"
             merge_parameterlist += "        FILE_WRITE     => false,\n" # don't write here since we write memory
             merge_parameterlist += "        NAME => \"" + mem + "\",\n"
-            merge_portlist += "        bx_in => TP_bx_out,\n"
-            merge_portlist += "        bx_in_vld => TP_bx_out_vld,\n"
+            merge_portlist += "        bx_in => "+mem+"_bx,\n"
+            merge_portlist += "        bx_in_vld => "+mem+"_bx_vld,\n"
             merge_portlist += "        rst => '0',\n"
             merge_portlist += "        clk => clk,\n"
             merge_portlist += "        merged_dout => "+mem+"_stream_V_dout,\n"
@@ -706,6 +720,17 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             mem_str += "    STREAM_"+mem+" : entity work.tf_merge_streamer\n"
             mem_str += "      generic map (\n"+merge_parameterlist.rstrip(",\n")+"\n      )\n"
             mem_str += "      port map (\n"+merge_portlist.rstrip(",\n")+"\n      );\n\n"
+
+            stream_delay_portlist = ""
+            stream_delay_portlist += "        clk        => clk,\n"
+            stream_delay_portlist += "        reset      => reset,\n"
+            stream_delay_portlist += "        bx_out     => TP_bx_out,\n"
+            stream_delay_portlist += "        bx_out_vld => TP_bx_out_vld,\n"
+            stream_delay_portlist += "        bx         => "+mem+"_bx,\n"
+            stream_delay_portlist += "        bx_vld     => "+mem+"_bx_vld,\n"
+            mem_str += "    "+mem+"_STREAM_DELAY : entity work.tf_pipeline_slr_xing\n"        
+            mem_str += "      port map (\n"+stream_delay_portlist.rstrip(",\n")+"\n      );\n\n"
+
         portlist += "        clkb      => clk,\n"
         portlist += "        rsta      => reset,\n"
         portlist += "        rstb      => '0',\n"

--- a/WriteVHDLSyntax.py
+++ b/WriteVHDLSyntax.py
@@ -111,7 +111,15 @@ def writeTopModuleEntityCloser(topmodule_name):
 def writeTBEntityBegin():
     string_begin = "begin\n\n"
     string_begin += "--! @brief Make clock ---------------------------------------\n"
-    string_begin += "  clk <= not clk after CLK_PERIOD/2;\n\n"
+    string_begin += "  clk <= not clk after CLK_PERIOD/2.0;"
+    string_begin += """
+  clk_wiz_240_360_0 : clk_wiz_240_360
+     port map (
+     clk    => clk,
+     clk240 => clk240,
+     clk360 => clk360,
+     locked => locked
+   );\n\n"""
     return string_begin
 
 def writeTopModuleCloser():
@@ -128,7 +136,7 @@ def writeTBMemoryStimulusProcess(initial_proc):
     # Stimulates reading and process start
     """
 
-    string_mem = "  procStart : process(CLK)\n"
+    string_mem = "  procStart : process(CLK240)\n"
     string_mem += "    -- Process to start first module in chain & generate its BX counter input.\n"
     string_mem += "    -- Also releases reset flag.\n"
     string_mem += "    constant CLK_RESET : natural := 5; -- Any low number OK.\n"
@@ -137,7 +145,7 @@ def writeTBMemoryStimulusProcess(initial_proc):
     string_mem += "    variable v_line : line; -- Line for debug\n"
     string_mem += "  begin\n\n"
     string_mem += "    if START_FIRST_" + ("WRITE" if "IR" not in initial_proc else "LINK") + " = '1' then\n"
-    string_mem += "      if rising_edge(CLK) then\n"
+    string_mem += "      if rising_edge(CLK240) then\n"
     string_mem += "        if (CLK_COUNT < MAX_ENTRIES) then\n"
     string_mem += "          CLK_COUNT := CLK_COUNT + 1;\n"
     string_mem += "        else\n"
@@ -182,13 +190,13 @@ def writeTBMemoryReadInstance(mtypeB, memDict, bxbitwidth, is_initial, is_binned
             string_mem += "  generic map (\n"
             memtmp = mem.replace("twoS","2S")
             string_mem += "      FILE_NAME".ljust(str_len) + "=> FILE_IN_"+mtypeB+"&\""+ memtmp + "\"&inputFileNameEnding,\n"
-            string_mem += "      DELAY".ljust(str_len) + "=> " + mtypeB.split("_")[0] + "_DELAY*MAX_ENTRIES,\n"
             string_mem += "      FIFO_WIDTH".ljust(str_len) + "=> " + mtypeB.split("_")[1] + ",\n"
             string_mem += "      DEBUG".ljust(str_len) + "=> true,\n"
             string_mem += "      FILE_NAME_DEBUG".ljust(str_len) + "=> FILE_OUT_DL_debug&\""+ memtmp + "\"&debugFileNameEnding\n"
             string_mem += "    )\n"
             string_mem += "    port map (\n"
-            string_mem += "      CLK".ljust(str_len) + "=> CLK,\n"
+            string_mem += "      CLK".ljust(str_len) + "=> CLK240,\n"
+            string_mem += "      LOCKED".ljust(str_len) + "=> LOCKED,\n"
             string_mem += "      READ_EN".ljust(str_len) + "=> " + mem + "_link_read,\n"
             string_mem += "      DATA".ljust(str_len) + "=> " + mem + "_link_AV_dout,\n"
             string_mem += "      START".ljust(str_len) + "=> " + ("START_" + mem + ",\n" if is_initial else "open,\n")
@@ -202,7 +210,6 @@ def writeTBMemoryReadInstance(mtypeB, memDict, bxbitwidth, is_initial, is_binned
                 memtmp = memtmp.replace("n1","")
             #    memtmp = "T"+mem[1:10]
             string_mem += "      FILE_NAME".ljust(str_len) + "=> FILE_IN_" + mtypeB+"&\""+ memtmp + "\"&inputFileNameEnding,\n"
-            string_mem += "      DELAY".ljust(str_len) + "=> " + mtypeB.split("_")[0] + "_DELAY*MAX_ENTRIES,\n"
             string_mem += "      RAM_WIDTH".ljust(str_len) + "=> " + mtypeB.split("_")[1] + ",\n"
             string_mem += "      NUM_PAGES".ljust(str_len) + "=> " + str(2**bxbitwidth) + ",\n"
             if "MPROJ" in mem:
@@ -217,7 +224,8 @@ def writeTBMemoryReadInstance(mtypeB, memDict, bxbitwidth, is_initial, is_binned
             string_mem += "      FILE_NAME_DEBUG".ljust(str_len) + "=> FILE_OUT_" + mtypeB+"&\""+ mem + "_debug\"&debugFileNameEnding\n"
             string_mem += "    )\n"
             string_mem += "    port map (\n"
-            string_mem += "      CLK".ljust(str_len) + "=> CLK,\n"
+            string_mem += "      CLK".ljust(str_len) + "=> CLK240,\n"
+            string_mem += "      LOCKED".ljust(str_len) + "=> LOCKED,\n"
             string_mem += "      ADDR".ljust(str_len) + "=> " + mem + "_writeaddr,\n"
             string_mem += "      DATA".ljust(str_len) + "=> " + mem + "_din,\n"
             string_mem += "      START".ljust(str_len) + "=> START_" + mem + ",\n" if is_initial else "      START => open,\n"
@@ -627,11 +635,11 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
 
             #FIXME implement delay for disks
         # Write ports
-        portlist += "        clka      => clk,\n"
+        portlist += "        clka      => clk240,\n"
         portlist += "        wea       => "+mem+"_wea_delay,\n"
         portlist += "        addra     => "+mem+"_writeaddr_delay,\n"
         portlist += "        dina      => "+mem+"_din_delay,\n"
-        delay_portlist += "        clk      => clk,\n"
+        delay_portlist += "        clk      => clk240,\n"
         delay_portlist += "        reset    => reset,\n"
         delay_portlist += "        wea       => "+mem+"_wea,\n"
         delay_portlist += "        addra     => "+mem+"_writeaddr,\n"
@@ -673,7 +681,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
                     merge_portlist += "        bx_in => TPAR"+seed+PCGroup+"_bx,\n"
                     merge_portlist += "        bx_in_vld => TPAR"+seed+PCGroup+"_bx_vld,\n"
                     merge_portlist += "        rst => '0',\n"
-                    merge_portlist += "        clk => clk,\n"
+                    merge_portlist += "        clk => clk240,\n"
                     #This will make output for first stream_merge module (is there a less hacky way?)
                     if first_merge_streamer: 
                       merge_portlist += "        bx_out => TP_bx_out_merged,\n"
@@ -712,7 +720,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             merge_portlist += "        bx_in => "+mem+"_bx,\n"
             merge_portlist += "        bx_in_vld => "+mem+"_bx_vld,\n"
             merge_portlist += "        rst => '0',\n"
-            merge_portlist += "        clk => clk,\n"
+            merge_portlist += "        clk => clk240,\n"
             merge_portlist += "        merged_dout => "+mem+"_stream_V_dout,\n"
             for i in range(4):  merge_portlist += "        din"+str(i)+"=>" +mem+"_V_dout,\n"
             for i in range(4):  merge_portlist += "        nent"+str(i)+"=>" +mem+"_AV_dout_nent,\n"
@@ -722,7 +730,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             mem_str += "      port map (\n"+merge_portlist.rstrip(",\n")+"\n      );\n\n"
 
             stream_delay_portlist = ""
-            stream_delay_portlist += "        clk        => clk,\n"
+            stream_delay_portlist += "        clk        => clk240,\n"
             stream_delay_portlist += "        reset      => reset,\n"
             stream_delay_portlist += "        bx_out     => TP_bx_out,\n"
             stream_delay_portlist += "        bx_out_vld => TP_bx_out_vld,\n"
@@ -731,7 +739,7 @@ def writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = False,
             mem_str += "    "+mem+"_STREAM_DELAY : entity work.tf_pipeline_slr_xing\n"        
             mem_str += "      port map (\n"+stream_delay_portlist.rstrip(",\n")+"\n      );\n\n"
 
-        portlist += "        clkb      => clk,\n"
+        portlist += "        clkb      => clk240,\n"
         portlist += "        rsta      => reset,\n"
         portlist += "        rstb      => '0',\n"
         if not memInfo.is_binned :
@@ -805,7 +813,8 @@ def writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, spl
     
     final_proc_short = final_procs[0].split("_")[0]
     string_ctrl_signals = ""
-    string_ctrl_signals += "    clk        : in std_logic;\n"
+    string_ctrl_signals += "    clk240     : in std_logic;\n"
+    string_ctrl_signals += "    clk360     : in std_logic;\n"
     string_ctrl_signals += "    reset      : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_start  : in std_logic;\n"
     string_ctrl_signals += "    "+initial_proc+"_bx_in : in std_logic_vector(2 downto 0);\n"
@@ -980,7 +989,7 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector, split):
     string_constants += "  --    N.B. Change this also in makeProject.tcl !\n"
     string_constants += "  constant INST_TOP_TF".ljust(str_len) + ": integer := 1; \n"
     string_constants += "  --=========================================================================\n\n"
-    string_constants += "  constant CLK_PERIOD".ljust(str_len) + ": time    := 4 ns;       --! 250 MHz\n"
+    string_constants += "  constant CLK_PERIOD".ljust(str_len) + ": time    := 25.0 ns;       --! 40 MHz\n"
     string_constants += "  constant DEBUG".ljust(str_len) + ": boolean := False;      --! Debug off/on\n"
  
     # Write delay and input/output file name signals
@@ -996,13 +1005,7 @@ def writeTBConstants(memDict, memInfoDict, procs, emData_dir, sector, split):
             if memInfo.mtype_short not in string_input_tmp:
                 mem_dir = memInfo.mtype_long.replace("AllStubs", "Stubs").replace("Inner", "").replace("Outer", "").replace("DTCLink", "InputStubs").replace("InputLink", "InputStubs").replace("FullMatch", "Matches").replace("AllProj", "TrackletProjections").replace("CandidateMatch", "Matches") # Directory name for the memory testvectors. FIX ME, make this prettier?!
                 mem_file_start = memInfo.mtype_long.replace("ME", "").replace("TE","").replace("Inner", "").replace("Outer", "").replace("DTC", "").replace("InputLink", "InputStubs").replace("FullMatch", "FullMatches").replace("CandidateMatch", "CandidateMatches") # Testvector file name start. FIX ME, make this prettier?!
-                mem_delay = procs.index(memInfo.downstream_mtype_short) # The delay in number of bx. The initial process of the chain will have 0 delay, the second have 1 bx delay etc.
 
-                #FIXME - hack for fpga2 project
-                if split == 2:
-                    mem_delay = 0
-
-                string_constants += ("  constant " + memInfo.mtype_short + "_DELAY").ljust(str_len) + ": integer := " + str(mem_delay) + ";          --! Number of BX delays\n"
                 string_input_tmp += ("  constant FILE_IN_" + mtypeB).ljust(str_len) + ": string := memPrintsDir&\"" + mem_dir + "/" + mem_file_start + "_\";\n"
                 if "VMSME_16" == mtypeB:
                     string_input_tmp += ("  constant FILE_IN_VMSME_17").ljust(str_len) + ": string := memPrintsDir&\"" + mem_dir + "/" + mem_file_start + "_\";\n"
@@ -1049,6 +1052,9 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_procs, notfi
     string_ctrl_signals = "\n  -- ########################### Signals ###########################\n"
     string_ctrl_signals += "  -- ### UUT signals ###\n"
     string_ctrl_signals += "  signal clk".ljust(str_len)+": std_logic := '0';\n"
+    string_ctrl_signals += "  signal clk240".ljust(str_len)+": std_logic;\n"
+    string_ctrl_signals += "  signal clk360".ljust(str_len)+": std_logic;\n"
+    string_ctrl_signals += "  signal locked".ljust(str_len)+": std_logic;\n"
     string_ctrl_signals += "  signal reset".ljust(str_len)+": std_logic := '1';\n"
     string_ctrl_signals += ("  signal "+initial_proc+"_start").ljust(str_len)+": std_logic := '0';\n"
     string_ctrl_signals += ("  signal "+initial_proc+"_idle").ljust(str_len)+": std_logic := '0';\n"
@@ -1178,6 +1184,17 @@ def writeTBControlSignals(memDict, memInfoDict, initial_proc, final_procs, notfi
         mem = memMod.inst
         string_ctrl_signals += "  signal START_" + mem + " : t_" + first_mem + "_1b" + " := '0';\n"
 
+    string_ctrl_signals += """
+  component clk_wiz_240_360
+  port
+   (
+    clk    : in     std_logic;
+    clk240 : out std_logic;
+    clk360 : out std_logic;
+    locked : out std_logic
+   );
+  end component;\n"""
+
     string_ctrl_signals += "\n"
 
     return string_ctrl_signals
@@ -1201,7 +1218,8 @@ def writeFWBlockInstance(topfunc, memDict, memInfoDict, initial_proc, final_proc
     string_fwblock_inst += "  begin\n"
     string_fwblock_inst += "    uut : entity work." + topfunc + "\n"
     string_fwblock_inst += "      port map(\n"
-    string_fwblock_inst += "        clk".ljust(str_len) + "=> clk,\n"
+    string_fwblock_inst += "        clk240".ljust(str_len) + "=> clk240,\n"
+    string_fwblock_inst += "        clk360".ljust(str_len) + "=> clk240, -- Using 240-MHz clock until CDC is integrated\n"
     string_fwblock_inst += "        reset".ljust(str_len) + "=> reset,\n"
     string_fwblock_inst += ("        " + initial_proc + "_start").ljust(str_len) + "=> " + initial_proc + "_start,\n"
     string_fwblock_inst += ("        " + initial_proc + "_bx_in").ljust(str_len) + "=> " + initial_proc + "_bx_in,\n"
@@ -1353,7 +1371,7 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned, 
             string_mem += "      FIFO_WIDTH".ljust(str_len)+"=> " + str(width) + "\n"
             string_mem += "    )\n"
             string_mem += "    port map (\n"
-            string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
+            string_mem += "      CLK".ljust(str_len)+"=> CLK240,\n"
             string_mem += "      DONE".ljust(str_len)+"=> TP_DONE,\n"
             string_mem += "      WRITE_EN".ljust(str_len)+"=> ("+mem+"_stream_V_dout(" + str(width - 1) + ")),\n"
             string_mem += "      FULL_NEG".ljust(str_len)+'=> open,\n'
@@ -1367,7 +1385,7 @@ def writeTBMemoryWriteRAMInstance(mtypeB, memDict, proc, bxbitwidth, is_binned, 
         string_mem += "      NUM_PAGES".ljust(str_len)+"=> " + str(2**bxbitwidth) + "\n"
         string_mem += "    )\n"
         string_mem += "    port map (\n"
-        string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
+        string_mem += "      CLK".ljust(str_len)+"=> CLK240,\n"
         string_mem += "      ADDR".ljust(str_len)+"=> "+mem+"_readaddr,\n"
         string_mem += "      DATA".ljust(str_len)+"=> "+mem+"_dout,\n"
         string_mem += "      READ_EN".ljust(str_len)+"=> "+mem+"_enb,\n"
@@ -1405,7 +1423,7 @@ def writeTBMemoryWriteFIFOInstance(mtypeB, memDict, proc):
         string_mem += "      FIFO_WIDTH".ljust(str_len)+"=> " + mtypeB.split("_")[1] + "\n"
         string_mem += "    )\n"
         string_mem += "    port map (\n"
-        string_mem += "      CLK".ljust(str_len)+"=> CLK,\n"
+        string_mem += "      CLK".ljust(str_len)+"=> CLK240,\n"
         string_mem += "      DONE".ljust(str_len)+"=> "+proc+"_DONE,\n"
         string_mem += "      WRITE_EN".ljust(str_len)+"=> ("+mem+"_stream_A_write and "+mem+"_stream_AV_din(" + str(memWidth - 1) + ")),\n"
         string_mem += "      FULL_NEG".ljust(str_len)+"=> "+mem+"_stream_A_full_neg,\n"
@@ -1429,7 +1447,7 @@ def writeProcCombination(module, str_ctrl_func, str_ports):
         module_str += "      NAME    => \""+module.inst+"_mem_reader\"\n"
         module_str += "    )\n"
         module_str += "    port map (\n"
-        module_str += "      clk    => clk,\n"
+        module_str += "      clk    => clk240,\n"
         module_str += "      bx    => "+module.inst+"_bx_in,\n"
         module_str += "      start => "+module.inst+"_start,\n"
         module_str += "      enb   => MPAR_"+module.inst[3:]+"in_enb,\n"
@@ -1449,7 +1467,7 @@ def writeProcCombination(module, str_ctrl_func, str_ports):
         module_str += "      NAME    => \""+module.inst+"_mem_reader\"\n"
         module_str += "    )\n"
         module_str += "    port map (\n"
-        module_str += "      clk    => clk,\n"
+        module_str += "      clk    => clk240,\n"
         module_str += "      bx    => "+module.inst+"_bx_in,\n"
         module_str += "      start => "+module.inst+"_start,\n"
         module_str += "      enb   => AS_"+module.inst[7:]+"in_enb,\n"
@@ -1503,7 +1521,7 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False, first_of_type=Fal
         int_ctrl_func += "      generic map (\n"+startsignal_parameter_list.rstrip(",\n")+"\n      )\n"
 
         int_ctrl_func += "    port map (\n"
-        int_ctrl_func += "      clk   => clk,\n"
+        int_ctrl_func += "      clk   => clk240,\n"
         int_ctrl_func += "      reset => reset,\n"
         int_ctrl_func += "      done  => PC_start,\n"
         int_ctrl_func += "      bx_out => PC_bx_in,\n"
@@ -1524,7 +1542,7 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False, first_of_type=Fal
     int_ctrl_wire += "  signal "+mtype+"_start : std_logic := '0';\n"
     int_ctrl_func += "  LATCH_"+mtype+": entity work.tf_pipeline_slr_xing\n"
     int_ctrl_func += "    port map (\n"
-    int_ctrl_func += "      clk   => clk,\n"
+    int_ctrl_func += "      clk   => clk240,\n"
     int_ctrl_func += "      reset => reset,\n"
     if "MP_" in mtype :
         int_ctrl_func += "      done  => PC_done,\n"
@@ -1549,7 +1567,7 @@ def writeStartSwitchAndInternalBX(module,mem,extraports=False, first_of_type=Fal
         int_ctrl_wire += "  signal "+mtype+"_bx_in : std_logic_vector(2 downto 0);\n"
         int_ctrl_func += "  LATCH_"+mtype+"_BX_GEN: entity work.tf_pipeline_slr_xing\n"
         int_ctrl_func += "    port map (\n"
-        int_ctrl_func += "      clk   => clk,\n"
+        int_ctrl_func += "      clk   => clk240,\n"
         int_ctrl_func += "      reset => reset,\n"
         if first_proc:
             if mtype_up == "VMSMER":
@@ -1567,7 +1585,7 @@ def writeProcControlSignalPorts(module,first_of_type):
     # Processing module port assignment: control signals
     """
     string_ctrl_ports = ""
-    string_ctrl_ports += "      ap_clk   => clk,\n"
+    string_ctrl_ports += "      ap_clk   => clk240,\n"
     string_ctrl_ports += "      ap_rst   => reset,\n"
     if (module.mtype_short()=="PC") :
         string_ctrl_ports += "      ap_start => '1',\n"
@@ -1721,7 +1739,7 @@ def writeLastTrackPorts(ftName, is_open):
 def writeLUTPorts(argname,lut):
     string_lut_ports = ""
     argname = argname.split("[")[0]
-    string_lut_ports += "      clk       => clk,\n"
+    string_lut_ports += "      clk       => clk240,\n"
     string_lut_ports += "      addr      => "+lut.inst+"_"+argname+"_addr,\n"
     string_lut_ports += "      ce        => "+lut.inst+"_"+argname+"_ce,\n"
     string_lut_ports += "      dout      => "+lut.inst+"_"+argname+"_dout\n"

--- a/generator_hdl.py
+++ b/generator_hdl.py
@@ -31,7 +31,7 @@ import os, subprocess
 # Memories
 ########################################
 
-def writeMemoryModules(memDict, memInfoDict, extraports , delay, split = 0, MPARdict = 0):
+def writeMemoryModules(memDict, memInfoDict, extraports , split = 0, MPARdict = 0):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -56,7 +56,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports , delay, split = 0, MPAR
         if (("VMSME" in mtypeB and split == 1) or ("TPROJ" in mtypeB and split == 1)):
             continue
 
-        string_wires_inst, string_mem_inst = writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, delay = delay, split = split, MPARdict = MPARdict)
+        string_wires_inst, string_mem_inst = writeTopLevelMemoryType(mtypeB, memList, memInfo, extraports, split = split, MPARdict = MPARdict)
         string_wires += string_wires_inst
         string_mem += string_mem_inst
     
@@ -65,7 +65,7 @@ def writeMemoryModules(memDict, memInfoDict, extraports , delay, split = 0, MPAR
 ########################################
 # Processing modules
 ########################################
-def writeProcModules(proc_list, hls_src_dir, extraports, delay, split = 0):
+def writeProcModules(proc_list, hls_src_dir, extraports, split = 0):
     """
     # proc_list:   a list of processing modules
     # hls_src_dir: string pointing to the HLS directory, used to extract constants
@@ -84,10 +84,10 @@ def writeProcModules(proc_list, hls_src_dir, extraports, delay, split = 0):
         if ("PC" in aProcMod.mtype or "VMSMER" in aProcMod.mtype) and split == 1:
             continue
         if not aProcMod.mtype in proc_type_list: # Is this aProcMod the first of its type
-            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports, delay, split)
+            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, True, extraports, split)
             proc_type_list.append(aProcMod.mtype)
         else:
-            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, False, extraports, delay, split)
+            proc_wire_inst,proc_func_inst = writeModuleInstance(aProcMod, hls_src_dir, False, extraports, split)
         string_proc_wire += proc_wire_inst
         string_proc_func += proc_func_inst
         
@@ -96,7 +96,7 @@ def writeProcModules(proc_list, hls_src_dir, extraports, delay, split = 0):
 ########################################
 # Top function interface
 ########################################
-def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, delay, split, streamIO=False, MPARdict = 0):
+def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,  extraports, split, streamIO=False, MPARdict = 0):
     """
     # topmodule_name:  name of the top module
     # process_list:    list of all processing functions in the block (in this function, this list is
@@ -128,7 +128,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
     string_topmod_interface = writeTopModuleOpener(topmodule_name)
 
     # Write control signals
-    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, delay = delay, split = split)
+    string_ctrl_signals = writeControlSignals_interface(initial_proc, final_procs, notfinal_procs, split = split)
     
     string_input_mems = ""
     string_output_mems = ""
@@ -169,7 +169,7 @@ def writeTopModule_interface(topmodule_name, process_list, memDict, memInfoDict,
 ########################################
 # Top file
 ########################################
-def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports, delay, split = False, MPARdict = 0):
+def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraports, split = False, MPARdict = 0):
     """
     # Inputs:
     #   memDict = dictionary of memories organised by type 
@@ -180,7 +180,7 @@ def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraport
     # Write memories
     string_memWires = ""
     string_memModules = ""
-    memWires_inst,memModules_inst = writeMemoryModules(memDict, memInfoDict, extraports, delay, split, MPARdict)
+    memWires_inst,memModules_inst = writeMemoryModules(memDict, memInfoDict, extraports, split, MPARdict)
     string_memWires   += memWires_inst
     string_memModules += memModules_inst
 
@@ -192,11 +192,11 @@ def writeTopFile(topfunc, process_list, memDict, memInfoDict, hls_dir, extraport
     # HLS source code directory
     source_dir = hls_dir.rstrip('/')+'/TrackletAlgorithm'
 
-    string_procWires, string_procModules = writeProcModules(process_list, source_dir, extraports, delay, split)
+    string_procWires, string_procModules = writeProcModules(process_list, source_dir, extraports, split)
 
     # Top function interface
     string_topmod_interface = writeTopModule_interface(topfunc, process_list,
-                                                       memDict, memInfoDict, extraports, delay, split, MPARdict=MPARdict)
+                                                       memDict, memInfoDict, extraports, split, MPARdict=MPARdict)
 
     string_src = ""
     string_src += writeTopPreamble()
@@ -473,8 +473,6 @@ if __name__ == "__main__":
                         help="Number of downstream processing steps to include")
     parser.add_argument('-x', '--extraports', action='store_true', 
                         help="Add debug ports corresponding to all BRAM inputs")
-    parser.add_argument('-de', '--delay', type=int, default=0,
-                        help="Number of pipeline stages in between processing and memory modules to include, setting 0 does not include pipeline modules")
     parser.add_argument('-sp', '--split', type =int, default=0,
                         help="enables split-fpga project, a value of 1 for first-fpga project, 2 for second-fpga, 0 for single fpga projects")
 
@@ -589,7 +587,7 @@ if __name__ == "__main__":
     ###############
     #  Top File
     string_topfile = writeTopFile(topfunc, process_list,
-                                  memDict, memInfoDict, args.hls_dir, args.extraports, args.delay, args.split, MPARdict = MPARdict)
+                                  memDict, memInfoDict, args.hls_dir, args.extraports, args.split, MPARdict = MPARdict)
 
     ###############
     # Test bench


### PR DESCRIPTION
This PR includes a couple updates to improve timing on FPGA1:
- Memory-specific signals are now used for *all* `sync_nent` ports. These signals already existed, but weren't used for some memories, so this update should reduce fanout for those signals.
- Pipelines were added for the BX signals going into the `tf_merge_streamer` modules, with a dedicated pipeline for each instance. Again, this should help reduce fanout for these signals, as well as adding extra shift registers so that they can traverse the FPGA over more clock cycles.

This PR also adds an extra clock port to the `SectorProcessor` so that both a 240- and 360-MHz clock can be plugged in. Both of these clocks are also generated in the test benches, although for now, only the 240-MHz clock is used.

Finally, the now-obsolete `regceb` port has been removed from the memory modules, and the delay argument has been removed from generator_hdl.py.